### PR TITLE
update inv_sqrt_degree (removing workaround)

### DIFF
--- a/mlx_graphs/utils/scatter.py
+++ b/mlx_graphs/utils/scatter.py
@@ -216,10 +216,7 @@ def degree(
 
 def invert_sqrt_degree(degree: mx.array) -> mx.array:
     """
-    Computes the inverted square root of the degree array. NOTE: This is a temporary
-    workaround to deal with infinite values according to the GCN paper as boolean
-    indexing isn't yet available, so we have to pre-pad zero elements of the degree
-    array (i.e. isolated nodes)
+    Computes the inverted square root of the degree array.
 
     Args:
         degree: Array of length num_nodes with the inverted square root degree of
@@ -227,11 +224,10 @@ def invert_sqrt_degree(degree: mx.array) -> mx.array:
 
     Returns:
         Array of length `num_nodes` with the inverted square root of the degree of
-        each node.
+        each node with 'inf' values zeroed out.
     """
-
-    minimal_value = mx.array(1e-6)
-    degree += minimal_value
     invert_sqrt_degree = degree ** (-0.5)
-    invert_sqrt_degree = mx.where(invert_sqrt_degree <= 1, invert_sqrt_degree, 0)
+    invert_sqrt_degree = mx.where(
+        invert_sqrt_degree == float("inf"), 0, invert_sqrt_degree
+    )
     return invert_sqrt_degree


### PR DESCRIPTION
## Proposed changes

Removed the workaround for 'inf' values in the normalization step of the GCN  #117  as it is natively handled in mlx.
Still need to potentially change this in case boolean indexing becomes available in mlx.

## Checklist

Put an `x` in the boxes that apply.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation
