### PR TITLE
Add temp_path fixture for deletion of files

### DIFF
--- a/tests/datasets/test_elliptic.py
+++ b/tests/datasets/test_elliptic.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-
 import mlx.core as mx
 import pytest
 
@@ -9,17 +6,14 @@ from mlx_graphs.loaders import Dataloader
 
 
 @pytest.mark.slow
-def test_elliptic_bitcoin_dataset():
+def test_elliptic_bitcoin_dataset(tmp_path):
     from torch_geometric.datasets import (
         EllipticBitcoinDataset as EllipticBitcoinDataset_torch,
     )
     from torch_geometric.loader import DataLoader
 
-    path = os.path.join("/".join(__file__.split("/")[:-1]), ".tests/")
-    shutil.rmtree(path, ignore_errors=True)
-
-    dataset = EllipticBitcoinDataset(base_dir=path)
-    dataset_torch = EllipticBitcoinDataset_torch(path)
+    dataset = EllipticBitcoinDataset(base_dir=tmp_path)
+    dataset_torch = EllipticBitcoinDataset_torch(tmp_path)
 
     train_loader = Dataloader(dataset, 10, shuffle=False)
     train_loader_torch = DataLoader(dataset_torch, 10, shuffle=False)
@@ -48,5 +42,3 @@ def test_elliptic_bitcoin_dataset():
             assert mx.array_equal(
                 mx.array(batch_pyg.test_mask.tolist()), batch_mxg.test_mask
             ), "Two arrays between PyG and mxg are different"
-
-    shutil.rmtree(path)

--- a/tests/datasets/test_planetoid.py
+++ b/tests/datasets/test_planetoid.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-
 import mlx.core as mx
 import pytest
 
@@ -19,15 +16,12 @@ from mlx_graphs.loaders import Dataloader
         ("pubmed", "public"),
     ],
 )
-def test_planetoid_cora_dataset(dataset_name, split):
+def test_planetoid_cora_dataset(tmp_path, dataset_name, split):
     from torch_geometric.datasets import Planetoid as Planetoid_torch
     from torch_geometric.loader import DataLoader
 
-    path = os.path.join("/".join(__file__.split("/")[:-1]), ".tests/")
-    shutil.rmtree(path, ignore_errors=True)
-
-    dataset = PlanetoidDataset(dataset_name, base_dir=path, split=split)
-    dataset_torch = Planetoid_torch(path, dataset_name, split=split)
+    dataset = PlanetoidDataset(dataset_name, base_dir=tmp_path, split=split)
+    dataset_torch = Planetoid_torch(tmp_path, dataset_name, split=split)
 
     train_loader = Dataloader(dataset, 10, shuffle=False)
     train_loader_torch = DataLoader(dataset_torch, 10, shuffle=False)
@@ -61,5 +55,3 @@ def test_planetoid_cora_dataset(dataset_name, split):
             assert mx.array_equal(
                 mx.array(batch_pyg.val_mask.tolist()), batch_mxg.val_mask
             ), "Two arrays between PyG and mxg are different"
-
-    shutil.rmtree(path)

--- a/tests/datasets/test_qm7b.py
+++ b/tests/datasets/test_qm7b.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-
 import mlx.core as mx
 import pytest
 
@@ -9,15 +6,12 @@ from mlx_graphs.loaders import Dataloader
 
 
 @pytest.mark.slow
-def test_qm7b_dataset():
+def test_qm7b_dataset(tmp_path):
     from torch_geometric.datasets import QM7b as QM7b_torch
     from torch_geometric.loader import DataLoader
 
-    path = os.path.join("/".join(__file__.split("/")[:-1]), ".tests/")
-    shutil.rmtree(path, ignore_errors=True)
-
-    dataset = QM7bDataset(base_dir=path)
-    dataset_torch = QM7b_torch(path)
+    dataset = QM7bDataset(base_dir=tmp_path)
+    dataset_torch = QM7b_torch(tmp_path)
 
     train_loader = Dataloader(dataset, 10, shuffle=False)
     train_loader_torch = DataLoader(dataset_torch, 10, shuffle=False)
@@ -36,5 +30,3 @@ def test_qm7b_dataset():
             assert mx.array_equal(
                 mx.array(batch_pyg.y.tolist()), batch_mxg.graph_labels
             ), "Two arrays between PyG and mxg are different"
-
-    shutil.rmtree(path)

--- a/tests/datasets/test_superpixel.py
+++ b/tests/datasets/test_superpixel.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-
 import mlx.core as mx
 import pytest
 
@@ -9,18 +6,12 @@ from mlx_graphs.loaders import Dataloader
 
 
 @pytest.mark.slow
-def test_superpixel_dataset():
+def test_superpixel_dataset(tmp_path):
     from torch_geometric.datasets import GNNBenchmarkDataset
     from torch_geometric.loader import DataLoader
 
-    path = os.path.join("/".join(__file__.split("/")[:-1]), ".tests/")
-    try:
-        shutil.rmtree(path)
-    except FileNotFoundError:
-        pass
-
-    dataset = SuperPixelDataset("MNIST", "test")  # , base_dir=path)
-    dataset_torch = GNNBenchmarkDataset(root=path, name="MNIST", split="test")
+    dataset = SuperPixelDataset("MNIST", "test", base_dir=tmp_path)  # , base_dir=path)
+    dataset_torch = GNNBenchmarkDataset(root=tmp_path, name="MNIST", split="test")
 
     train_loader = Dataloader(dataset, 10, shuffle=False)
     train_loader_torch = DataLoader(dataset_torch, 10, shuffle=False)
@@ -33,5 +24,3 @@ def test_superpixel_dataset():
         assert mx.array_equal(
             mx.array(batch_pyg.y.tolist()), batch_mxg.graph_labels
         ), "Graph labels are different"
-
-    shutil.rmtree(path)

--- a/tests/datasets/test_tu_dataset.py
+++ b/tests/datasets/test_tu_dataset.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-
 import mlx.core as mx
 import pytest
 
@@ -9,16 +6,14 @@ from mlx_graphs.loaders import Dataloader
 
 
 @pytest.mark.slow
-def test_tu_dataset():
+def test_tu_dataset(tmp_path):
     from torch_geometric.datasets import TUDataset as TUDataset_torch
     from torch_geometric.loader import DataLoader
 
     dataset_name = "ENZYMES"
-    path = os.path.join("/".join(__file__.split("/")[:-1]), ".tests/")
-    shutil.rmtree(path, ignore_errors=True)
 
-    dataset = TUDataset(dataset_name, base_dir=path)
-    dataset_torch = TUDataset_torch(path, dataset_name)
+    dataset = TUDataset(dataset_name, base_dir=tmp_path)
+    dataset_torch = TUDataset_torch(tmp_path, dataset_name)
 
     train_loader = Dataloader(dataset, 10, shuffle=False)
     train_loader_torch = DataLoader(dataset_torch, 10, shuffle=False)
@@ -42,5 +37,3 @@ def test_tu_dataset():
             assert mx.array_equal(
                 mx.array(batch_pyg.y.tolist()), batch_mxg.graph_labels
             ), "Two arrays between PyG and mxg are different"
-
-    shutil.rmtree(path)


### PR DESCRIPTION
Added a temp_path fixture which will delete temporary files created while running tests.

## Proposed changes
Currently, deletion of files is handles within the tests by the users.
Using a temp_path will allow storing the files for the duration of tests 
and will automatically be deleted once the tests are done

Please include a description of the problem or feature this PR is addressing.
If there is a corresponding issue, include the issue #.
Fix for #148 
## Checklist

Put an `x` in the boxes that apply.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation
