### PR TITLE
Add utils to convert networkx to GraphData

### DIFF
--- a/docs/source/api/utils/convert.rst
+++ b/docs/source/api/utils/convert.rst
@@ -12,3 +12,4 @@ Convert
 	:toctree: _autosummary_convert
 
 	to_networkx
+	from_networkx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
-autodoc_mock_imports = ["mlx"]
+autodoc_mock_imports = ["mlx", "networkx"]
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -59,6 +59,7 @@ html_theme_options = {
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "mlx": ("https://ml-explore.github.io/mlx/build/html", None),
+    "networkx": ("https://networkx.org/documentation/stable", None),
 }
 
 html_css_files = [

--- a/mlx_graphs/utils/convert.py
+++ b/mlx_graphs/utils/convert.py
@@ -59,7 +59,7 @@ def to_networkx(
     for i in range(data.num_nodes):
         if data.node_features is not None:
             node_attrs["features"] = data.node_features[i].tolist()
-        if data.node_labels:
+        if data.node_labels is not None:
             node_attrs["label"] = data.node_labels[i].item()
         G.add_node(i, **node_attrs)
 

--- a/mlx_graphs/utils/convert.py
+++ b/mlx_graphs/utils/convert.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
-from typing import Any
+from typing import Any, Union
 
 import mlx.core as mx
+import networkx as nx
 
 from mlx_graphs.data import GraphData
 
@@ -33,14 +34,13 @@ def to_networkx(
         OutEdgeView([(0, 0), (0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2)])
 
     """
-    import networkx as nx
 
     G = nx.DiGraph()
 
-    if data.graph_features:
+    if data.graph_features is not None:
         G.graph["graph_features"] = data.graph_features.tolist()
 
-    if data.graph_labels:
+    if data.graph_labels is not None:
         G.graph["graph_labels"] = data.graph_labels.tolist()
 
     if data.num_nodes is None:
@@ -71,7 +71,36 @@ def to_networkx(
     return G
 
 
-def from_networkx(data: Any) -> GraphData:
+def from_networkx(data: Union[nx.Graph]) -> GraphData:
+    """Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
+    :class:`mlx_graphs.data.GraphData` instance.
+
+    Args:
+        data (Union[nx.Graph]): A networkx graph
+
+    Returns:
+        GraphData: A GraphData object of type mlx_graphs.GraphData
+
+    Examples:
+        >>> from mlx_graphs.utils.convert import from_networkx
+        >>> import networkx as nx
+        >>> G = nx.Graph()
+        >>> G.add_node(1)
+        >>> G.add_node(2)
+        >>> G.add_node(3)
+        >>> G.add_node(4)
+        >>> G.add_edge(1, 2)
+        >>> G.add_edge(1, 3)
+        >>> G.add_edge(2, 3)
+        >>> G.add_edge(3, 4)
+        >>> mlx_dataset = from_networkx(G)
+        >>> mlx_dataset
+        GraphData(
+                edge_index(shape=(2, 4), int32))
+        >>> mlx_dataset.num_nodes
+        4
+
+    """
     data_dict = defaultdict(list)
 
     edge_index = mx.array(list(data.edges())).T

--- a/mlx_graphs/utils/convert.py
+++ b/mlx_graphs/utils/convert.py
@@ -1,8 +1,15 @@
 from collections import defaultdict
-from typing import Any, Union
+from typing import Any
 
 import mlx.core as mx
-import networkx as nx
+
+try:
+    import networkx as nx
+except ImportError:
+    raise ImportError(
+        "networkx is required to convert from nextworkx graphs",
+        "run `pip install networkx`",
+    )
 
 from mlx_graphs.data import GraphData
 
@@ -48,30 +55,26 @@ def to_networkx(
 
     # G.add_nodes_from(range(data.num_nodes))
 
-    node_features_present = data.node_features is not None
-    node_labels_present = data.node_labels is not None
-
     node_attrs = {}
     for i in range(data.num_nodes):
-        if node_features_present:
+        if data.node_features is not None:
             node_attrs["features"] = data.node_features[i].tolist()
-        if node_labels_present:
+        if data.node_labels:
             node_attrs["label"] = data.node_labels[i].item()
         G.add_node(i, **node_attrs)
 
-    edge_features_present = data.edge_features is not None
     edge_attrs = {}
     for i, (v, w) in enumerate(data.edge_index.T.tolist()):
         if remove_self_loops and v == w:
             continue
-        if edge_features_present:
+        if data.edge_features is not None:
             edge_attrs["features"] = data.edge_features[i].tolist()
         G.add_edge(v, w, **edge_attrs)
 
     return G
 
 
-def from_networkx(data: Union[nx.Graph]) -> GraphData:
+def from_networkx(data: nx.Graph) -> GraphData:
     """Converts a :obj:`networkx.Graph` or :obj:`networkx.DiGraph` to a
     :class:`mlx_graphs.data.GraphData` instance.
 

--- a/mlx_graphs/utils/convert.py
+++ b/mlx_graphs/utils/convert.py
@@ -6,7 +6,7 @@ try:
     import networkx as nx
 except ImportError:
     raise ImportError(
-        "networkx is required to convert from nextworkx graphs",
+        "networkx is required to convert to/from nextworkx graphs",
         "run `pip install networkx`",
     )
 
@@ -25,19 +25,26 @@ def to_networkx(
         remove_self_loops: If set to :obj:`True`, will not
             include self-loops in the resulting graph. (default: :obj:`False`)
 
+    Returns:
+        A networkx graph
+
     Examples:
-        >>> import mlx.core as mx
-        >>> edge_index = mx.array(
-        ...     [
-        ...         [0, 1, 1, 2, 2, 3],
-        ...         [1, 0, 2, 1, 3, 2],
-        ...     ]
-        ... )
-        >>> node_features = mx.array([[1], [1], [1], [1]])
-        >>> data = GraphData(node_features=node_features, edge_index=edge_index)
-        >>> G = to_networkx(data)
-        >>> G.edges
-        OutEdgeView([(0, 0), (0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2)])
+
+    .. code-block:: python
+
+        import mlx.core as mx
+
+        edge_index = mx.array(
+            [
+                [0, 1, 1, 2, 2, 3],
+                [1, 0, 2, 1, 3, 2],
+            ]
+        )
+        node_features = mx.array([[1], [1], [1], [1]])
+        data = GraphData(node_features=node_features, edge_index=edge_index)
+        G = to_networkx(data)
+        print(G.edges)
+        >>> OutEdgeView([(0, 0), (0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2)])
 
     """
 
@@ -51,8 +58,6 @@ def to_networkx(
 
     if data.num_nodes is None:
         return G
-
-    # G.add_nodes_from(range(data.num_nodes))
 
     node_attrs = {}
     for i in range(data.num_nodes):
@@ -78,29 +83,32 @@ def from_networkx(data: nx.Graph) -> GraphData:
     :class:`mlx_graphs.data.GraphData` instance.
 
     Args:
-        data (Union[nx.Graph]): A networkx graph
+        data: A networkx graph
 
     Returns:
-        GraphData: A GraphData object of type mlx_graphs.GraphData
+        A GraphData object
 
     Examples:
-        >>> from mlx_graphs.utils.convert import from_networkx
-        >>> import networkx as nx
-        >>> G = nx.Graph()
-        >>> G.add_node(1)
-        >>> G.add_node(2)
-        >>> G.add_node(3)
-        >>> G.add_node(4)
-        >>> G.add_edge(1, 2)
-        >>> G.add_edge(1, 3)
-        >>> G.add_edge(2, 3)
-        >>> G.add_edge(3, 4)
-        >>> mlx_dataset = from_networkx(G)
-        >>> mlx_dataset
-        GraphData(
-                edge_index(shape=(2, 4), int32))
-        >>> mlx_dataset.num_nodes
-        4
+
+    .. code-block:: python
+
+        import networkx as nx
+        from mlx_graphs.utils.convert import from_networkx
+
+        G = nx.Graph()
+        G.add_node(1)
+        G.add_node(2)
+        G.add_node(3)
+        G.add_node(4)
+        G.add_edge(1, 2)
+        G.add_edge(1, 3)
+        G.add_edge(2, 3)
+        G.add_edge(3, 4)
+        mlx_dataset = from_networkx(G)
+        print(mlx_dataset)
+        >>> GraphData(edge_index(shape=(2, 4), int32))
+        print(mlx_dataset.num_nodes)
+        >>> 4
 
     """
     data_dict = defaultdict(list)

--- a/mlx_graphs/utils/convert.py
+++ b/mlx_graphs/utils/convert.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Any
 
 import mlx.core as mx
 
@@ -17,7 +16,7 @@ from mlx_graphs.data import GraphData
 def to_networkx(
     data: GraphData,
     remove_self_loops: bool = False,
-) -> Any:
+) -> nx.DiGraph:
     r"""Converts a :class:`mlx_graphs.data.GraphData` instance to a
     a directed :obj:`networkx.DiGraph` otherwise.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "mlx==0.7.*; sys_platform == 'darwin'",
     "numpy==1.26.3",
     "requests==2.31.0",
-    "networkx",
     "fsspec==2024.2.0",
     "tqdm==4.66.1",
 ]
@@ -32,6 +31,7 @@ dev = [
 test = [
   "pytest==7.4.4",
   "scipy==1.12.0",
+  "networkx",
 ]
 docs = [
   "ipython==8.21.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "mlx==0.7.*; sys_platform == 'darwin'",
     "numpy==1.26.3",
     "requests==2.31.0",
+    "networkx",
     "fsspec==2024.2.0",
     "tqdm==4.66.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 test = [
   "pytest==7.4.4",
   "scipy==1.12.0",
-  "networkx",
+  "networkx==3.2.1",
 ]
 docs = [
   "ipython==8.21.0",

--- a/tests/utils/test_convert.py
+++ b/tests/utils/test_convert.py
@@ -1,17 +1,10 @@
-import importlib.util
-
 import mlx.core as mx
-import pytest
 
 from mlx_graphs.data import GraphData
 from mlx_graphs.datasets import KarateClubDataset
 from mlx_graphs.utils.convert import from_networkx, to_networkx
 
-networkx_spec = importlib.util.find_spec("networkx")
-networkx_installed = networkx_spec is not None
 
-
-@pytest.mark.skipif(not networkx_installed, reason="networkx is not installed")
 def test_to_networkx():
     # GraphData with edge_index and node_features
     edge_index = mx.array([[0, 0, 1, 1, 2, 2, 3], [0, 1, 0, 2, 1, 3, 2]])
@@ -52,7 +45,6 @@ def test_to_networkx():
     assert networkx_graph.number_of_edges() == 0
 
 
-@pytest.mark.skipif(not networkx_installed, reason="networkx is not installed")
 def test_from_networkx():
     karate_club_dataset = KarateClubDataset()
     karate_club_networkx_graph = to_networkx(karate_club_dataset.graphs[0])

--- a/tests/utils/test_convert.py
+++ b/tests/utils/test_convert.py
@@ -52,16 +52,27 @@ def test_to_networkx():
     assert networkx_graph.number_of_edges() == 0
 
 
+@pytest.mark.skipif(not networkx_installed, reason="networkx is not installed")
 def test_from_networkx():
     karate_club_dataset = KarateClubDataset()
     karate_club_networkx_graph = to_networkx(karate_club_dataset.graphs[0])
     restored_karate_club_dataset = from_networkx(karate_club_networkx_graph)
 
+    assert (
+        restored_karate_club_dataset.num_nodes
+        == karate_club_networkx_graph.number_of_nodes()
+    ), "Number of nodes are not equal"
+
+    assert (
+        restored_karate_club_dataset.num_edges
+        == karate_club_networkx_graph.number_of_edges()
+    ), "Number of edges are not equal"
+
     assert mx.array_equal(
         restored_karate_club_dataset.node_features,
-        karate_club_dataset.graphs[0].node_features,
+        karate_club_dataset[0].node_features,
     ), "Node features are not equal"
     assert (
         restored_karate_club_dataset.edge_index.shape[1]
-        == karate_club_dataset.graphs[0].edge_index.shape[1]
+        == karate_club_dataset[0].edge_index.shape[1]
     ), "Edge index shapes are not equal"

--- a/tests/utils/test_convert.py
+++ b/tests/utils/test_convert.py
@@ -4,7 +4,8 @@ import mlx.core as mx
 import pytest
 
 from mlx_graphs.data import GraphData
-from mlx_graphs.utils.convert import to_networkx
+from mlx_graphs.datasets import KarateClubDataset
+from mlx_graphs.utils.convert import from_networkx, to_networkx
 
 networkx_spec = importlib.util.find_spec("networkx")
 networkx_installed = networkx_spec is not None
@@ -23,6 +24,16 @@ def test_to_networkx():
     assert networkx_graph.number_of_nodes() == 4
     assert networkx_graph.number_of_edges() == len(edge_index[0])
 
+    for node in networkx_graph.nodes():
+        assert (
+            "features" in networkx_graph.nodes[node]
+        ), f"Node {node} does not have 'features' attribute"
+
+    for i in range(graph.num_nodes):
+        assert mx.array_equal(
+            mx.array(networkx_graph.nodes[i]["features"]), graph.node_features[i]
+        ), f"Node {i} features do not match"
+
     networkx_graph_no_self_loops = to_networkx(graph, remove_self_loops=True)
     assert networkx_graph_no_self_loops.number_of_edges() == len(edge_index[0]) - 1
 
@@ -39,3 +50,18 @@ def test_to_networkx():
 
     assert networkx_graph.number_of_nodes() == 0
     assert networkx_graph.number_of_edges() == 0
+
+
+def test_from_networkx():
+    karate_club_dataset = KarateClubDataset()
+    karate_club_networkx_graph = to_networkx(karate_club_dataset.graphs[0])
+    restored_karate_club_dataset = from_networkx(karate_club_networkx_graph)
+
+    assert mx.array_equal(
+        restored_karate_club_dataset.node_features,
+        karate_club_dataset.graphs[0].node_features,
+    ), "Node features are not equal"
+    assert (
+        restored_karate_club_dataset.edge_index.shape[1]
+        == karate_club_dataset.graphs[0].edge_index.shape[1]
+    ), "Edge index shapes are not equal"


### PR DESCRIPTION
1. Updated to_networkx function to add node, graph and edge features as well as labels
2. Added from_networkx utility to convert networkx.graph object to GraphData.

## Proposed changes

Fix for #110 

## Checklist

Put an `x` in the boxes that apply.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation
