### PR TITLE
Additional utils ( for isolated nodes and self loops)

### DIFF
--- a/docs/source/api/utils/transformations.rst
+++ b/docs/source/api/utils/transformations.rst
@@ -20,3 +20,5 @@ Transformations
 	remove_duplicate_directed_edges
 	coalesce
 	mask_isolated_nodes
+	has_isolated_nodes
+	has_self_loops

--- a/docs/source/api/utils/transformations.rst
+++ b/docs/source/api/utils/transformations.rst
@@ -19,3 +19,4 @@ Transformations
 	to_undirected
 	remove_duplicate_directed_edges
 	coalesce
+	mask_isolated_nodes

--- a/docs/source/api/utils/transformations.rst
+++ b/docs/source/api/utils/transformations.rst
@@ -19,6 +19,6 @@ Transformations
 	to_undirected
 	remove_duplicate_directed_edges
 	coalesce
-	mask_isolated_nodes
+	get_isolated_nodes_mask
 	has_isolated_nodes
 	has_self_loops

--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional, Union
 import mlx.core as mx
 import numpy as np
 
-from mlx_graphs.utils import remove_self_loops
+from mlx_graphs.utils import has_isolated_nodes, has_self_loops
 
 
 class GraphData:
@@ -179,10 +179,8 @@ class GraphData:
     def has_isolated_nodes(self) -> bool:
         """Returns a boolean of whether the graph has isolated nodes or not.
         (ie: nodes that does not have an edge with any other nodes )"""
-        edge_index, num_nodes = self.edge_index, self.num_nodes
-        edge_index = remove_self_loops(edge_index)
-        return np.unique(edge_index.reshape(-1)).size < num_nodes
+        return has_isolated_nodes(self.edge_index, self.num_nodes)
 
     def has_self_loops(self) -> bool:
         """Returns a boolean of whether the graph contains self loops."""
-        return ((self.edge_index[0] == self.edge_index[1]).sum() > 0).item()
+        return has_self_loops(self.edge_index)

--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -3,6 +3,8 @@ from typing import Literal, Optional, Union
 import mlx.core as mx
 import numpy as np
 
+from mlx_graphs.utils import remove_self_loops
+
 
 class GraphData:
     """
@@ -173,3 +175,12 @@ class GraphData:
         if "index" in key:
             return self.num_nodes
         return None
+
+    def has_isolated_nodes(self) -> bool:
+        """Returns a boolean of wether the graph has isolated nodes or not"""
+        edge_index, num_nodes = self.edge_index, self.num_nodes
+        edge_index = remove_self_loops(edge_index)
+        return np.unique(edge_index.reshape(-1)).size < num_nodes
+
+    def has_self_loops(self) -> bool:
+        return (self.edge_index[0] == self.edge_index[1]).sum().item() > 0

--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -184,5 +184,5 @@ class GraphData:
         return np.unique(edge_index.reshape(-1)).size < num_nodes
 
     def has_self_loops(self) -> bool:
-        """Returns a boolean of whether the graph contains self loops"""
+        """Returns a boolean of whether the graph contains self loops."""
         return ((self.edge_index[0] == self.edge_index[1]).sum() > 0).item()

--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -177,8 +177,8 @@ class GraphData:
         return None
 
     def has_isolated_nodes(self) -> bool:
-        """Returns a boolean of whether the graph has isolated nodes or not.
-        (ie: nodes that does not have an edge with any other nodes )"""
+        """Returns a boolean of whether the graph has isolated nodes or not
+        (i.e., nodes that don't have a link to any other nodes)"""
         return has_isolated_nodes(self.edge_index, self.num_nodes)
 
     def has_self_loops(self) -> bool:

--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -177,10 +177,12 @@ class GraphData:
         return None
 
     def has_isolated_nodes(self) -> bool:
-        """Returns a boolean of wether the graph has isolated nodes or not"""
+        """Returns a boolean of whether the graph has isolated nodes or not.
+        (ie: nodes that does not have an edge with any other nodes )"""
         edge_index, num_nodes = self.edge_index, self.num_nodes
         edge_index = remove_self_loops(edge_index)
         return np.unique(edge_index.reshape(-1)).size < num_nodes
 
     def has_self_loops(self) -> bool:
-        return (self.edge_index[0] == self.edge_index[1]).sum().item() > 0
+        """Returns a boolean of whether the graph contains self loops"""
+        return ((self.edge_index[0] == self.edge_index[1]).sum() > 0).item()

--- a/mlx_graphs/utils/__init__.py
+++ b/mlx_graphs/utils/__init__.py
@@ -9,5 +9,7 @@ from .transformations import (
     remove_self_loops,  # noqa
     remove_duplicate_directed_edges,  # noqa
     coalesce,  # noqa
+    has_isolated_nodes,  # noqa
+    has_self_loops,  # noqa
 )
 from .array_ops import expand, broadcast, one_hot, pairwise_distances, index_to_mask  # noqa

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -456,3 +456,17 @@ def mask_isolated_nodes(
         return mx.array(indices)
 
     return mx.array(np.setdiff1d(np.arange(num_nodes), indices))
+
+
+@validate_edge_index
+def has_isolated_nodes(edge_index: mx.array, num_nodes: int) -> bool:
+    """Returns a boolean of whether the graph has isolated nodes or not.
+    (ie: nodes that does not have an edge with any other nodes )"""
+    edge_index = remove_self_loops(edge_index)
+    return np.unique(edge_index.reshape(-1)).size < num_nodes
+
+
+@validate_edge_index
+def has_self_loops(edge_index: mx.array) -> bool:
+    """Returns a boolean of whether the graph contains self loops"""
+    return ((edge_index[0] == edge_index[1]).sum() > 0).item()

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -427,12 +427,15 @@ def coalesce(edge_index: mx.array) -> mx.array:
 
 
 @validate_edge_index
-def mask_isolated_nodes(edge_index: mx.array, num_nodes: int) -> mx.array:
+def mask_isolated_nodes(
+    edge_index: mx.array, num_nodes: int, filter_isolated: bool = True
+) -> mx.array:
     """Returns a mask with isolated nodes set to ``False`` to filter them out if needed.
 
     Args:
         edge_index : edge index from which to remove isolated nodes.
-        num_nodes (int): number of nodes of the graph.
+        num_nodes : number of nodes of the graph.
+        filter_isolated : wether to filter isolated or non isolated nodes.
 
     Returns:
         a boolean mask of size ``num_nodes`` where ``True`` means the node isn't
@@ -442,11 +445,14 @@ def mask_isolated_nodes(edge_index: mx.array, num_nodes: int) -> mx.array:
         >>> edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
         >>> mask = remove_isolated_nodes(edge_index, 3)
         >>> mask
-        mx.array([True, False, True])
+        mx.array([0,2])
+        >>> mask = remove_isolated_nodes(edge_index, 3, filter_isolated=False)
+        >>> mask
+        mx.array([1])
     """
     edge_index = remove_self_loops(edge_index)
-    mask = mx.zeros(num_nodes, dtype=mx.uint32)
-    mask[edge_index.reshape(-1)] = 1
-    mask = np.unique(mx.arange(num_nodes) * mask)
+    indices = np.unique(edge_index.reshape(-1))
+    if filter_isolated:
+        return mx.array(indices)
 
-    return mx.array(mask, dtype=mx.uint32)
+    return mx.array(np.setdiff1d(np.arange(num_nodes), indices))

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -427,15 +427,15 @@ def coalesce(edge_index: mx.array) -> mx.array:
 
 
 @validate_edge_index
-def mask_isolated_nodes(
-    edge_index: mx.array, num_nodes: int, filter_isolated: bool = True
+def get_isolated_nodes_mask(
+    edge_index: mx.array, num_nodes: int, complement: bool = True
 ) -> mx.array:
     """Returns a mask with isolated nodes set to ``False`` to filter them out if needed.
 
     Args:
         edge_index : Edge index from which to remove isolated nodes.
         num_nodes : Number of nodes of the graph.
-        filter_isolated : Wether to filter isolated or non isolated nodes.
+        complement : Wether to filter isolated or non isolated nodes.
 
     Returns:
         A boolean mask of size ``num_nodes`` where ``True`` means the node isn't
@@ -443,16 +443,16 @@ def mask_isolated_nodes(
 
     Example :
         >>> edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
-        >>> mask = mask_isolated_nodes(edge_index, 3)
+        >>> mask = get_isolated_nodes_mask(edge_index, 3)
         >>> mask
         mx.array([0,2])
-        >>> mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
+        >>> mask = get_isolated_nodes_mask(edge_index, 3, complement=False)
         >>> mask
         mx.array([1])
     """
     edge_index = remove_self_loops(edge_index)
     indices = np.unique(edge_index.reshape(-1))
-    if filter_isolated:
+    if complement:
         return mx.array(indices)
 
     return mx.array(np.setdiff1d(np.arange(num_nodes), indices))

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -445,7 +445,8 @@ def mask_isolated_nodes(edge_index: mx.array, num_nodes: int) -> mx.array:
         mx.array([True, False, True])
     """
     edge_index = remove_self_loops(edge_index)
-    mask = mx.zeros(num_nodes, dtype=mx.bool_)
+    mask = mx.zeros(num_nodes, dtype=mx.uint32)
     mask[edge_index.reshape(-1)] = 1
+    mask = np.unique(mx.arange(num_nodes) * mask)
 
-    return mask
+    return mx.array(mask, dtype=mx.uint32)

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -424,3 +424,28 @@ def coalesce(edge_index: mx.array) -> mx.array:
     edge_index = mx.stack([col, row])
 
     return edge_index
+
+
+@validate_edge_index
+def mask_isolated_nodes(edge_index: mx.array, num_nodes: int) -> mx.array:
+    """Returns a mask with isolated nodes set to ``False`` to filter them out if needed.
+
+    Args:
+        edge_index : edge index from which to remove isolated nodes.
+        num_nodes (int): number of nodes of the graph.
+
+    Returns:
+        a boolean mask of size ``num_nodes`` where ``True`` means the node isn't
+        isolated and ``false``means it is.
+
+    Example :
+        >>> edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
+        >>> mask = remove_isolated_nodes(edge_index, 3)
+        >>> mask
+        mx.array([True, False, True])
+    """
+    edge_index = remove_self_loops(edge_index)
+    mask = mx.zeros(num_nodes, dtype=mx.bool_)
+    mask[edge_index.reshape(-1)] = 1
+
+    return mask

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -433,20 +433,20 @@ def mask_isolated_nodes(
     """Returns a mask with isolated nodes set to ``False`` to filter them out if needed.
 
     Args:
-        edge_index : edge index from which to remove isolated nodes.
-        num_nodes : number of nodes of the graph.
-        filter_isolated : wether to filter isolated or non isolated nodes.
+        edge_index : Edge index from which to remove isolated nodes.
+        num_nodes : Number of nodes of the graph.
+        filter_isolated : Wether to filter isolated or non isolated nodes.
 
     Returns:
-        a boolean mask of size ``num_nodes`` where ``True`` means the node isn't
-        isolated and ``false``means it is.
+        A boolean mask of size ``num_nodes`` where ``True`` means the node isn't
+        isolated and ``False``means it is.
 
     Example :
         >>> edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
-        >>> mask = remove_isolated_nodes(edge_index, 3)
+        >>> mask = mask_isolated_nodes(edge_index, 3)
         >>> mask
         mx.array([0,2])
-        >>> mask = remove_isolated_nodes(edge_index, 3, filter_isolated=False)
+        >>> mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
         >>> mask
         mx.array([1])
     """

--- a/mlx_graphs/utils/transformations.py
+++ b/mlx_graphs/utils/transformations.py
@@ -460,13 +460,34 @@ def mask_isolated_nodes(
 
 @validate_edge_index
 def has_isolated_nodes(edge_index: mx.array, num_nodes: int) -> bool:
-    """Returns a boolean of whether the graph has isolated nodes or not.
-    (ie: nodes that does not have an edge with any other nodes )"""
+    """Function to check for isolated nodes.
+    (i.e. : nodes that don't have a link to any other nodes )
+    Args:
+        edge_index : Edge index on which to check for isolated nodes.
+    Returns:
+        A boolean of whether the graph has isolated nodes.
+
+    Example :
+        >>> edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
+        >>> has_self_loops(edge_index, 3)
+        True
+    """
     edge_index = remove_self_loops(edge_index)
     return np.unique(edge_index.reshape(-1)).size < num_nodes
 
 
 @validate_edge_index
 def has_self_loops(edge_index: mx.array) -> bool:
-    """Returns a boolean of whether the graph contains self loops"""
+    """Function to check for self loops.
+    Args:
+        edge_index : Edge index on which to check for self loops.
+    Returns:
+        A boolean of whether the graph has self loops.
+
+    Example :
+        >>> edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
+        >>> has_self_loops(edge_index)
+        True
+    """
+
     return ((edge_index[0] == edge_index[1]).sum() > 0).item()

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -106,29 +106,3 @@ def test_data_num_features():
     assert data.num_node_features == 0, "GraphData num_features failed"
     assert data.num_edge_features == 0, "GraphData num_features failed"
     assert data.num_graph_features == 0, "GraphData num_features failed"
-
-
-def test_data_has_isolated_nodes():
-    data = GraphData(
-        edge_index=mx.array([[0, 1, 0], [1, 0, 0]]),
-        node_features=mx.array([[1], [1], [1], [1]]),
-    )
-    assert data.has_isolated_nodes() is True, "GraphData has_isolated_nodes failed"
-
-    data = GraphData(edge_index=mx.array([[0, 1, 0], [1, 0, 0]]))
-    assert data.has_isolated_nodes() is False, "GraphData has_isolated_nodes failed"
-
-    data = GraphData(
-        edge_index=mx.array([[0, 1, 0], [1, 0, 0]]), node_features=mx.array([[1], [1]])
-    )
-    assert data.has_isolated_nodes() is False, "GraphData has_isolated_nodes failed"
-
-
-def test_data_has_self_loops():
-    data = GraphData(edge_index=mx.array([[0, 1, 0], [1, 0, 0]]))
-
-    assert data.has_self_loops() is True, "GraphData has_self_loops failed"
-
-    data = GraphData(edge_index=mx.array([[0, 1], [1, 0]]))
-
-    assert data.has_self_loops() is False, "GraphData has_self_loops failed"

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -106,3 +106,29 @@ def test_data_num_features():
     assert data.num_node_features == 0, "GraphData num_features failed"
     assert data.num_edge_features == 0, "GraphData num_features failed"
     assert data.num_graph_features == 0, "GraphData num_features failed"
+
+
+def test_data_has_isolated_nodes():
+    data = GraphData(
+        edge_index=mx.array([[0, 1, 0], [1, 0, 0]]),
+        node_features=mx.array([[1], [1], [1], [1]]),
+    )
+    assert data.has_isolated_nodes() is True, "GraphData has_isolated_nodes failed"
+
+    data = GraphData(edge_index=mx.array([[0, 1, 0], [1, 0, 0]]))
+    assert data.has_isolated_nodes() is False, "GraphData has_isolated_nodes failed"
+
+    data = GraphData(
+        edge_index=mx.array([[0, 1, 0], [1, 0, 0]]), node_features=mx.array([[1], [1]])
+    )
+    assert data.has_isolated_nodes() is False, "GraphData has_isolated_nodes failed"
+
+
+def test_data_has_self_loops():
+    data = GraphData(edge_index=mx.array([[0, 1, 0], [1, 0, 0]]))
+
+    assert data.has_self_loops() is True, "GraphData has_self_loops failed"
+
+    data = GraphData(edge_index=mx.array([[0, 1], [1, 0]]))
+
+    assert data.has_self_loops() is False, "GraphData has_self_loops failed"

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -214,15 +214,18 @@ def test_remove_duplicated_directed_edges():
 def test_mask_isolated_nodes():
     edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
     mask = mask_isolated_nodes(edge_index, 2)
-    expected_mask = mx.array([True, True])
+    expected_mask = mx.array([0, 1], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
 
     edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
     mask = mask_isolated_nodes(edge_index, 3)
-    expected_mask = mx.array([True, True, False])
+    expected_mask = mx.array([0, 1], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
 
     edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
     mask = mask_isolated_nodes(edge_index, 3)
-    expected_mask = mx.array([True, False, True])
+    expected_mask = mx.array([0, 2], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+
+
+test_mask_isolated_nodes()

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -217,14 +217,24 @@ def test_mask_isolated_nodes():
     expected_mask = mx.array([0, 1], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
 
-    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+    edge_index = mx.array([[1, 2], [2, 1]])
     mask = mask_isolated_nodes(edge_index, 3)
-    expected_mask = mx.array([0, 1], dtype=mx.uint32)
+    expected_mask = mx.array([1, 2], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
 
     edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
     mask = mask_isolated_nodes(edge_index, 3)
     expected_mask = mx.array([0, 2], dtype=mx.uint32)
+    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+
+    edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
+    mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
+    expected_mask = mx.array([1], dtype=mx.uint32)
+    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+
+    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+    mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
+    expected_mask = mx.array([2], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
 
 

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -3,10 +3,10 @@ import pytest
 
 from mlx_graphs.utils.transformations import (
     add_self_loops,
+    get_isolated_nodes_mask,
     get_unique_edge_indices,
     has_isolated_nodes,
     has_self_loops,
-    mask_isolated_nodes,
     remove_duplicate_directed_edges,
     remove_self_loops,
     to_adjacency_matrix,
@@ -215,29 +215,29 @@ def test_remove_duplicated_directed_edges():
 
 def test_mask_isolated_nodes():
     edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
-    mask = mask_isolated_nodes(edge_index, 2)
+    mask = get_isolated_nodes_mask(edge_index, 2)
     expected_mask = mx.array([0, 1], dtype=mx.uint32)
-    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+    assert mx.array_equal(mask, expected_mask), "get_isolated_nodes_mask failed"
 
     edge_index = mx.array([[1, 2], [2, 1]])
-    mask = mask_isolated_nodes(edge_index, 3)
+    mask = get_isolated_nodes_mask(edge_index, 3)
     expected_mask = mx.array([1, 2], dtype=mx.uint32)
-    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+    assert mx.array_equal(mask, expected_mask), "get_isolated_nodes_mask failed"
 
     edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
-    mask = mask_isolated_nodes(edge_index, 3)
+    mask = get_isolated_nodes_mask(edge_index, 3)
     expected_mask = mx.array([0, 2], dtype=mx.uint32)
-    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+    assert mx.array_equal(mask, expected_mask), "get_isolated_nodes_mask failed"
 
     edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
-    mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
+    mask = get_isolated_nodes_mask(edge_index, 3, complement=False)
     expected_mask = mx.array([1], dtype=mx.uint32)
-    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+    assert mx.array_equal(mask, expected_mask), "get_isolated_nodes_mask failed"
 
     edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
-    mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
+    mask = get_isolated_nodes_mask(edge_index, 3, complement=False)
     expected_mask = mx.array([2], dtype=mx.uint32)
-    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+    assert mx.array_equal(mask, expected_mask), "get_isolated_nodes_mask failed"
 
 
 def test_has_isolated_nodes():

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -4,6 +4,7 @@ import pytest
 from mlx_graphs.utils.transformations import (
     add_self_loops,
     get_unique_edge_indices,
+    mask_isolated_nodes,
     remove_duplicate_directed_edges,
     remove_self_loops,
     to_adjacency_matrix,
@@ -208,3 +209,20 @@ def test_remove_duplicated_directed_edges():
     expected_index = mx.array([[0, 0, 2, 2], [1, 2, 1, 2]])
     new_index = remove_duplicate_directed_edges(edge_index)
     assert mx.array_equal(new_index, expected_index)
+
+
+def test_mask_isolated_nodes():
+    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+    mask = mask_isolated_nodes(edge_index, 2)
+    expected_mask = mx.array([True, True])
+    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+
+    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+    mask = mask_isolated_nodes(edge_index, 3)
+    expected_mask = mx.array([True, True, False])
+    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+
+    edge_index = mx.array([[0, 2, 0], [2, 0, 0]])
+    mask = mask_isolated_nodes(edge_index, 3)
+    expected_mask = mx.array([True, False, True])
+    assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -4,6 +4,8 @@ import pytest
 from mlx_graphs.utils.transformations import (
     add_self_loops,
     get_unique_edge_indices,
+    has_isolated_nodes,
+    has_self_loops,
     mask_isolated_nodes,
     remove_duplicate_directed_edges,
     remove_self_loops,
@@ -236,3 +238,21 @@ def test_mask_isolated_nodes():
     mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
     expected_mask = mx.array([2], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
+
+
+def test_has_isolated_nodes():
+    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+    assert has_isolated_nodes(edge_index, 3) is True, "has_isolated_nodes failed"
+
+    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+    assert has_isolated_nodes(edge_index, 2) is False, "has_isolated_nodes failed"
+
+
+def test_has_self_loops():
+    edge_index = mx.array([[0, 1, 0], [1, 0, 0]])
+
+    assert has_self_loops(edge_index) is True, "has_self_loops failed"
+
+    edge_index = mx.array([[0, 1], [1, 0]])
+
+    assert has_self_loops(edge_index) is False, "has_self_loops failed"

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -236,6 +236,3 @@ def test_mask_isolated_nodes():
     mask = mask_isolated_nodes(edge_index, 3, filter_isolated=False)
     expected_mask = mx.array([2], dtype=mx.uint32)
     assert mx.array_equal(mask, expected_mask), "mask_isolated_nodes failed"
-
-
-test_mask_isolated_nodes()


### PR DESCRIPTION
## Proposed changes

Added some graph utilities 

- has_isolated_nodes
- mask_isolated_nodes (return mask) so that user can filter out isolated nodes from node features 
- has_self_loops



## Checklist

Put an `x` in the boxes that apply.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation
