### PR TITLE
make edge_index required in GraphData

### DIFF
--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -30,7 +30,7 @@ class GraphData:
 
     def __init__(
         self,
-        edge_index: Optional[mx.array] = None,
+        edge_index: mx.array,
         node_features: Optional[mx.array] = None,
         edge_features: Optional[mx.array] = None,
         graph_features: Optional[mx.array] = None,
@@ -72,23 +72,18 @@ class GraphData:
         return {k: v for k, v in self.__dict__.items() if v is not None}
 
     @property
-    def num_nodes(self) -> Union[int, None]:
+    def num_nodes(self) -> int:
         """Number of nodes in the graph."""
         if self.node_features is not None:
             return self.node_features.shape[0]
-
-        # NOTE: This may be slow for large graphs
-        elif self.edge_index is not None:
-            return np.unique(self.edge_index).size
-        return None
+        else:
+            # NOTE: This may be slow for large graphs
+            return np.unique(np.array(self.edge_index, copy=False)).size
 
     @property
-    def num_edges(self) -> Union[int, None]:
+    def num_edges(self) -> int:
         """Number of edges in the graph"""
-        if self.edge_index is not None:
-            return self.edge_index.shape[1]
-
-        return None
+        return self.edge_index.shape[1]
 
     @property
     def num_node_classes(self) -> int:

--- a/mlx_graphs/nn/conv/gcn_conv.py
+++ b/mlx_graphs/nn/conv/gcn_conv.py
@@ -52,7 +52,7 @@ class GCNConv(MessagePassing):
         row, col = edge_index
 
         # Compute node degree normalization for the mean aggregation.
-        norm: mx.array = None
+        norm: Optional[mx.array] = None
         if normalize:
             deg = degree(col, node_features.shape[0], edge_weights=edge_weights)
             # NOTE : need boolean indexing in order to zero out inf values

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -5,7 +5,7 @@ from mlx_graphs.data import GraphData
 
 def test_data_repr():
     # kwargs
-    data = GraphData(a=2)
+    data = GraphData(edge_index=mx.array([[0], [0]]), a=2)
     assert data.a == 2, "extra kwarg not assigned correctly"  # type: ignore
     assert "a" in data.to_dict(), "extra kwarg not in dict"
 
@@ -36,41 +36,48 @@ def test_data_repr():
 
 def test_data_num_classes():
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.array([1, 2, 3, 4, 5]),
         node_labels=mx.expand_dims(mx.arange(10), 0),
     )
     assert data.num_node_classes == 10, "GraphData num_classes failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.array([1, 2, 3, 4, 5]),
         edge_labels=mx.expand_dims(mx.arange(10), 0),
     )
     assert data.num_edge_classes == 10, "GraphData num_classes failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.array([1, 2, 3, 4, 5]),
         graph_labels=mx.expand_dims(mx.arange(10), 0),
     )
     assert data.num_graph_classes == 10, "GraphData num_classes failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.array([1, 2, 3, 4, 5]),
         node_labels=mx.array([0.1, 0.4, 0.6, 0.8]),
     )
     assert data.num_node_classes == 4, "GraphData num_classes failed"
 
     data = GraphData(
-        node_features=mx.array([1, 2, 3, 4, 5]), node_labels=mx.array([1, 2, 3, 4])
+        edge_index=mx.array([[0], [0]]),
+        node_features=mx.array([1, 2, 3, 4, 5]),
+        node_labels=mx.array([1, 2, 3, 4]),
     )
     assert data.num_node_classes == 4, "GraphData num_classes failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.array([1, 2, 3, 4, 5]),
         node_labels=mx.array(mx.expand_dims(mx.array([1, 2, 3, 4]), 1)),
     )
     assert data.num_node_classes == 4, "GraphData num_classes failed"
 
-    data = GraphData()
+    data = GraphData(edge_index=mx.array([[0], [0]]))
     assert data.num_node_classes == 0, "GraphData num_classes failed"
     assert data.num_edge_classes == 0, "GraphData num_classes failed"
     assert data.num_graph_classes == 0, "GraphData num_classes failed"
@@ -78,21 +85,25 @@ def test_data_num_classes():
 
 def test_data_num_features():
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.array([1, 2, 3, 4, 5]),
     )
     assert data.num_node_features == 1, "GraphData num_features failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         node_features=mx.ones((5, 10)),
     )
     assert data.num_node_features == 10, "GraphData num_features failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         edge_features=mx.ones((5, 10)),
     )
     assert data.num_edge_features == 10, "GraphData num_features failed"
 
     data = GraphData(
+        edge_index=mx.array([[0], [0]]),
         graph_features=mx.ones((5, 10)),
     )
     assert data.num_graph_features == 10, "GraphData num_features failed"
@@ -102,7 +113,7 @@ def test_data_num_features():
     )
     assert data.num_edges == 10, "GraphData num_features failed"
 
-    data = GraphData()
+    data = GraphData(edge_index=mx.array([[0], [0]]))
     assert data.num_node_features == 0, "GraphData num_features failed"
     assert data.num_edge_features == 0, "GraphData num_features failed"
     assert data.num_graph_features == 0, "GraphData num_features failed"

--- a/tests/data/test_dataloaders.py
+++ b/tests/data/test_dataloaders.py
@@ -1,9 +1,11 @@
+import mlx.core as mx
+
 from mlx_graphs.data import GraphData
 from mlx_graphs.loaders import Dataloader
 
 
 def test_dataloader():
-    data = [GraphData(), GraphData(), GraphData(), GraphData()]
+    data = [GraphData(edge_index=mx.array([[0], [0]]))] * 4
 
     # test batch 1
     dl = Dataloader(data, batch_size=1)

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -10,13 +10,18 @@ from mlx_graphs.data.utils import (
 @pytest.mark.parametrize(
     "x, expected_exception",
     [
-        ([GraphData()], None),  # ok
+        ([GraphData(edge_index=mx.array([[0], [1]]))], None),  # ok
         ([1, 2, 3], ValueError),  # not list of GraphData
-        ([GraphData(), 1], ValueError),  # list with spurious items
+        (
+            [GraphData(edge_index=mx.array([[0], [1]])), 1],
+            ValueError,
+        ),  # list with spurious items
         (
             [
                 GraphData(edge_index=mx.array([[0], [1]])),
-                GraphData(node_features=mx.array([[1]])),
+                GraphData(
+                    edge_index=mx.array([[0], [0]]), node_features=mx.array([[1]])
+                ),
             ],
             ValueError,
         ),  # GraphData with different attributes

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -21,6 +21,7 @@ def test_fake_dataset():
 
 def test_dataset_properties(tmp_path):
     data = GraphData(
+        edge_index=mx.ones((2, 10)),
         node_features=mx.ones((10, 5)),
         edge_labels=mx.ones((10, 1)),
     )
@@ -79,7 +80,11 @@ def test_dataset_properties(tmp_path):
 
 def test_dataset_transform(tmp_path):
     data_list = [
-        GraphData(node_features=mx.ones((10, 5)), edge_labels=mx.ones((10, 1)))
+        GraphData(
+            edge_index=mx.ones((2, 10)),
+            node_features=mx.ones((10, 5)),
+            edge_labels=mx.ones((10, 1)),
+        )
         for _ in range(3)
     ]
 

--- a/tests/transforms/test_normalize_features.py
+++ b/tests/transforms/test_normalize_features.py
@@ -12,7 +12,9 @@ def test_normalize_features():
     assert str(transform) == "FeaturesNormalizedTransform()"
 
     node_features = mx.array([[1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]])
-    data = GraphData(node_features=node_features)
+    data = GraphData(
+        edge_index=mx.array([[0, 1, 2], [1, 2, 0]]), node_features=node_features
+    )
 
     norm_data = transform(data)
     assert norm_data.node_features.tolist() == [[0.5, 0, 0.5], [0, 1, 0], [0, 0, 0]]

--- a/tests/utils/test_convert.py
+++ b/tests/utils/test_convert.py
@@ -37,13 +37,6 @@ def test_to_networkx():
     assert networkx_graph.number_of_nodes() == 2
     assert networkx_graph.number_of_edges() == 2
 
-    # Empty GraphData
-    graph = GraphData()
-    networkx_graph = to_networkx(graph)
-
-    assert networkx_graph.number_of_nodes() == 0
-    assert networkx_graph.number_of_edges() == 0
-
 
 def test_from_networkx():
     karate_club_dataset = KarateClubDataset()


### PR DESCRIPTION
## Proposed changes

This makes `edge_index` a required arg when instantiating a `GraphData`. It allows not having to check whether the edge_index is not None within the framework. I think it's fair to assume that having and `edge_index` is the minimum requirement for a `GraphData`.

## Checklist

Put an `x` in the boxes that apply.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation
