### PR TITLE
Add new dataset class for HeterographData

### DIFF
--- a/docs/source/api/datasets/index.rst
+++ b/docs/source/api/datasets/index.rst
@@ -11,6 +11,7 @@ Datasets
 	:template: dataset-class-template.rst
 
 	Dataset
+	HeteroDataset
 
 
 .. autosummary::

--- a/mlx_graphs/data/data.py
+++ b/mlx_graphs/data/data.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import mlx.core as mx
 import numpy as np
@@ -239,13 +239,13 @@ class HeteroGraphData:
 
     def __init__(
         self,
-        edge_index_dict: dict[tuple[str, str, str], mx.array],
+        edge_index_dict: dict[Any, mx.array],
         node_features_dict: Optional[dict[str, mx.array]] = None,
-        edge_features_dict: Optional[dict[str, mx.array]] = None,
+        edge_features_dict: Optional[dict[Any, mx.array]] = None,
         graph_features: Optional[mx.array] = None,
         node_labels_dict: Optional[dict[str, mx.array]] = None,
-        edge_labels_dict: Optional[dict[str, mx.array]] = None,
-        edge_labels_index_dict: Optional[dict[str, mx.array]] = None,
+        edge_labels_dict: Optional[dict[Any, mx.array]] = None,
+        edge_labels_index_dict: Optional[dict[Any, mx.array]] = None,
         graph_labels: Optional[mx.array] = None,
         **kwargs,
     ) -> None:
@@ -363,7 +363,7 @@ class HeteroGraphData:
             for node_type, node_features in self.node_features_dict.items():
                 num_nodes[node_type] = node_features.shape[0]
         else:
-            for edge_type, edge_index in self.edge_index_dict:
+            for edge_type, edge_index in self.edge_index_dict.items():
                 src_node_type, _, dst_node_type = edge_type
                 if src_node_type not in num_nodes:
                     num_nodes[src_node_type] = np.unique(
@@ -383,7 +383,7 @@ class HeteroGraphData:
         return 1 if self.graph_features.ndim == 1 else self.graph_features.shape[-1]
 
     @property
-    def num_edges(self) -> dict[str, int]:
+    def num_edges(self) -> dict[Any, int]:
         """dictionary of number of edges for each edge type in the graph."""
         return {
             edge_type: edge_index.shape[1]
@@ -404,7 +404,7 @@ class HeteroGraphData:
         return None
 
     @property
-    def num_edge_classes(self) -> dict[str, int]:
+    def num_edge_classes(self) -> dict[Any, int]:
         """
         Returns a dictionary of the number of edge classes
         for each edge type in the current graph.
@@ -436,7 +436,7 @@ class HeteroGraphData:
                 )
         return num_edge_features_dict
 
-    def _num_classes(self, task: Literal["node", "edge"], type_key: str) -> int:
+    def _num_classes(self, task: Literal["node", "edge"], type_key: Any) -> int:
         labels_dict = getattr(self, f"{task}_labels_dict")
         if labels_dict is None or type_key not in labels_dict:
             return 0
@@ -476,7 +476,7 @@ class HeteroGraphData:
             is_undirected(
                 self.edge_index_dict[edge_type],
                 (
-                    self.edge_features_dict.get(edge_type, None)
+                    self.edge_features_dict.get(edge_type, None)  # type: ignore
                     if self.edge_features_dict
                     else None
                 ),

--- a/mlx_graphs/datasets/__init__.py
+++ b/mlx_graphs/datasets/__init__.py
@@ -1,3 +1,4 @@
+from .base_dataset import BaseDataset  # noqa
 from .dataset import Dataset  # noqa
 from .heteroGraphDataset import HeteroGraphDataset  # noqa
 from .karate_club import KarateClubDataset  # noqa

--- a/mlx_graphs/datasets/__init__.py
+++ b/mlx_graphs/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .dataset import Dataset  # noqa
+from .heteroGraphDataset import HeteroGraphDataset  # noqa
 from .karate_club import KarateClubDataset  # noqa
 from .qm7b import QM7bDataset  # noqa
 from .tu_dataset import TUDataset  # noqa

--- a/mlx_graphs/datasets/__init__.py
+++ b/mlx_graphs/datasets/__init__.py
@@ -1,6 +1,6 @@
 from .base_dataset import BaseDataset  # noqa
 from .dataset import Dataset  # noqa
-from .heteroGraphDataset import HeteroGraphDataset  # noqa
+from .hetero_dataset import HeteroDataset  # noqa
 from .karate_club import KarateClubDataset  # noqa
 from .qm7b import QM7bDataset  # noqa
 from .tu_dataset import TUDataset  # noqa

--- a/mlx_graphs/datasets/base_dataset.py
+++ b/mlx_graphs/datasets/base_dataset.py
@@ -7,13 +7,26 @@ DEFAULT_BASE_DIR = os.path.join(os.getcwd(), ".mlx_graphs_data/")
 
 
 class BaseDataset(ABC):
+    """
+    Abstract base class for datasets.
+
+    Args:
+        name: The name of the dataset.
+        base_dir: The base directory where the dataset is stored.
+            Default is in the local directory ``.mlx_graphs_data/``.
+        pre_transform: A function to apply as a pre-transform to each graph in the
+            dataset. Defaults to None.
+        transform : A function to apply as a transform to each graph in the dataset.
+            Defaults to None.
+    """
+
     def __init__(
         self,
         name: str,
         base_dir: Optional[str] = None,
         pre_transform: Optional[Callable] = None,
         transform: Optional[Callable] = None,
-    ) -> None:
+    ):
         self._name = name
         self._base_dir = base_dir if base_dir else DEFAULT_BASE_DIR
         self.transform = transform

--- a/mlx_graphs/datasets/base_dataset.py
+++ b/mlx_graphs/datasets/base_dataset.py
@@ -1,0 +1,109 @@
+import os
+import pickle
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional, Sequence, Union
+
+DEFAULT_BASE_DIR = os.path.join(os.getcwd(), ".mlx_graphs_data/")
+
+
+class BaseDataset(ABC):
+    def __init__(
+        self,
+        name: str,
+        base_dir: Optional[str] = None,
+        pre_transform: Optional[Callable] = None,
+        transform: Optional[Callable] = None,
+    ) -> None:
+        self._name = name
+        self._base_dir = base_dir if base_dir else DEFAULT_BASE_DIR
+        self.transform = transform
+        self.pre_transform = pre_transform
+        self.graphs = []
+        self._load()
+
+    @property
+    def name(self) -> str:
+        """Name of the dataset"""
+        return self._name
+
+    @property
+    def raw_path(self) -> str:
+        """The path where raw files are stored."""
+        return os.path.expanduser(os.path.join(self._base_dir, self.name, "raw"))
+
+    @property
+    def processed_path(self) -> str:
+        """The path where processed files are stored."""
+        return os.path.expanduser(os.path.join(self._base_dir, self.name, "processed"))
+
+    @property
+    def num_items(self) -> int:
+        """Returns the number of items in the dataset."""
+        return len(self)
+
+    @abstractmethod
+    def download(self):
+        """Download the dataset at `self.raw_path`."""
+        pass
+
+    @abstractmethod
+    def process(self):
+        """Process the dataset and store data in `self.data`"""
+        pass
+
+    def save(self):
+        """Save the processed dataset"""
+        with open(os.path.join(self.processed_path, "graphs.pkl"), "wb") as f:
+            pickle.dump(self.graphs, f)
+
+    def load(self):
+        """Load the processed dataset"""
+        with open(os.path.join(self.processed_path, "graphs.pkl"), "rb") as f:
+            obj = pickle.load(f)
+            self.graphs = obj
+
+    def _download(self):
+        if self._base_dir is not None and self.raw_path is not None:
+            if os.path.exists(self.raw_path):
+                return
+            os.makedirs(self.raw_path, exist_ok=True)
+            print(f"Downloading {self.name} raw data ...", end=" ")
+            self.download()
+            print("Done")
+
+    def _process(self):
+        self.process()
+
+        if self.pre_transform:
+            print(f"Applying pre-transform to {self.name} data ...", end=" ")
+            self.graphs = [self.pre_transform(graph) for graph in self.graphs]
+            print("Done")
+
+    def _save(self):
+        if self._base_dir is not None and self.processed_path is not None:
+            if not os.path.exists(self.processed_path):
+                os.makedirs(self.processed_path, exist_ok=True)
+        print(f"Saving processed {self.name} data ...", end=" ")
+        self.save()
+        print("Done")
+
+    def _load(self):
+        # try to load the already processed dataset, if unavailable download
+        # and process the raw data and save the processed one
+        try:
+            print(f"Loading {self.name} data ...", end=" ")
+            self.load()
+            print("Done")
+        except FileNotFoundError:
+            self._download()
+            print(f"Processing {self.name} raw data ...", end=" ")
+            self._process()
+            print("Done")
+            self._save()
+
+    def __len__(self):
+        return len(self.graphs)
+
+    @abstractmethod
+    def __getitem__(self, idx: Union[int, slice, Sequence]) -> Any:
+        pass

--- a/mlx_graphs/datasets/dataset.py
+++ b/mlx_graphs/datasets/dataset.py
@@ -6,27 +6,27 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import GraphData
-from mlx_graphs.datasets import BaseDataset
-
-# Default path for downloaded datasets is the current working directory
-DEFAULT_BASE_DIR = os.path.join(os.getcwd(), ".mlx_graphs_data/")
+from mlx_graphs.datasets.base_dataset import DEFAULT_BASE_DIR, BaseDataset
 
 
 class Dataset(BaseDataset):
     """
-    Base dataset class. ``download`` and ``process`` methods must be
+    A dataset class for graph data. ``download`` and ``process`` methods must be
     implemented by children classes. The ``save`` and ``load`` methods save and load
     only the processed ``self.graphs`` attribute by default. You may want to
     override them to store/load additional processed attributes.
 
     Graph data within the dataset should be stored in ``self.graphs`` as
-    a List[GraphData]. The creation and preprocessing of this list of graphs
+    a `list[GraphData]`. The creation and preprocessing of this list of graphs
     is typically done within the overridden ``process`` method.
 
     Args:
         name: name of the dataset
         base_dir: Directory where to store dataset files. Default is
             in the local directory ``.mlx_graphs_data/``.
+        pre_transform: A function/transform that takes in a ``GraphData`` object and
+            returns a transformed version. The transformation is applied before
+            the first access.
         transform: A function/transform that takes in a ``GraphData`` object and returns
             a transformed version. The transformation is applied before every access,
             i.e., during the ``__getitem__`` call.

--- a/mlx_graphs/datasets/dblp.py
+++ b/mlx_graphs/datasets/dblp.py
@@ -81,7 +81,7 @@ class DBLP(HeteroGraphDataset):
         node_features_dict = {}
         for i, node_type in enumerate(node_types[:2]):
             nodes = sp.load_npz(osp.join(self.raw_path, f"features_{i}.npz"))
-            node_features_dict[node_type] = mx.array(nodes.todense())
+            node_features_dict[node_type] = mx.array(nodes.todense()).astype(mx.float32)
 
         term = np.load(osp.join(self.raw_path, "features_2.npy"))
         node_features_dict["term"] = mx.array(term).astype(mx.float32)

--- a/mlx_graphs/datasets/dblp.py
+++ b/mlx_graphs/datasets/dblp.py
@@ -7,11 +7,11 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import HeteroGraphData
-from mlx_graphs.datasets import HeteroGraphDataset
+from mlx_graphs.datasets import HeteroDataset
 from mlx_graphs.datasets.utils import download, extract_archive
 
 
-class DBLP(HeteroGraphDataset):
+class DBLP(HeteroDataset):
     """
     A subset of the DBLP computer science bibliography website, as
     collected in the `"MAGNN: Metapath Aggregated Graph Neural Network for
@@ -93,7 +93,7 @@ class DBLP(HeteroGraphDataset):
         # it explicitly to a dictionary will not make sense.
         # Either override the property in the class or set attribute separately
         # for conference
-        conference_nodes = int((node_type_idx == 3).sum().item())
+        conference_nodes = int((node_type_idx == 3).sum().item())  # type: ignore
 
         node_labels_dict = {}
         y = np.load(osp.join(self.raw_path, "labels.npy"))
@@ -110,7 +110,7 @@ class DBLP(HeteroGraphDataset):
         for name in ["train", "val", "test"]:
             idx = split[f"{name}_idx"]
             idx = mx.array(idx, dtype=mx.int64)
-            mask = mx.zeros(data.num_nodes["author"], dtype=mx.bool_)
+            mask = mx.zeros(data.num_nodes["author"], dtype=mx.bool_)  # type: ignore
             mask[idx] = True
             setattr(data, f"author_{name}_mask", mask)
 

--- a/mlx_graphs/datasets/dblp.py
+++ b/mlx_graphs/datasets/dblp.py
@@ -7,11 +7,11 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import HeteroGraphData
-from mlx_graphs.datasets.dataset import Dataset
+from mlx_graphs.datasets import HeteroGraphDataset
 from mlx_graphs.datasets.utils import download, extract_archive
 
 
-class DBLP(Dataset):
+class DBLP(HeteroGraphDataset):
     """
     A subset of the DBLP computer science bibliography website, as
     collected in the `"MAGNN: Metapath Aggregated Graph Neural Network for

--- a/mlx_graphs/datasets/heteroGraphDataset.py
+++ b/mlx_graphs/datasets/heteroGraphDataset.py
@@ -1,0 +1,109 @@
+import copy
+import os
+from typing import Callable, Optional, Sequence, Union
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_graphs.data import HeteroGraphData
+from mlx_graphs.datasets import Dataset
+
+DEFAULT_BASE_DIR = os.path.join(os.getcwd(), ".mlx_graphs_data/")
+
+
+class HeteroGraphDataset(Dataset):
+    def __init__(
+        self,
+        name: str,
+        base_dir: Optional[str] = None,
+        pre_transform: Optional[Callable] = None,
+        transform: Optional[Callable] = None,
+    ):
+        self._name = name
+        self._base_dir = base_dir if base_dir else DEFAULT_BASE_DIR
+        self.transform = transform
+        self.pre_transform = pre_transform
+        self.graphs: Union[list[HeteroGraphData]] = []
+        self._load()
+
+    @property
+    def num_node_features(self) -> dict[str, int]:
+        """Returns a dictionary of the number of node features for each node type."""
+        return self.graphs[0].num_node_features
+
+    @property
+    def num_edge_features(self) -> dict[str, int]:
+        """Returns a dictionary of the number of edge features for each edge type."""
+        return self.graphs[0].num_edge_features
+
+    @property
+    def num_graph_features(self) -> int:
+        """Returns the number of graph features."""
+        return self.graphs[0].num_graph_features
+
+    @property
+    def num_node_classes(self) -> Union[dict[str, int], None]:
+        """Returns a dictionary of the number of node classes for each node type."""
+        return self.graphs[0].num_node_classes
+
+    @property
+    def num_edge_classes(self) -> dict[str, int]:
+        """Returns a dictionary of the number of edge classes for each edge type."""
+        return self.graphs[0].num_edge_classes
+
+    @property
+    def num_nodes(self) -> dict[str, int]:
+        """Returns a dictionary of the number of nodes for each node type."""
+        return self.graphs[0].num_nodes
+
+    @property
+    def num_edges(self) -> dict[str, int]:
+        """Returns a dictionary of the number of edges for each edge type."""
+        return self.graphs[0].num_edges
+
+    def __getitem__(
+        self,
+        idx: Union[int, np.integer, slice, mx.array, np.ndarray, Sequence],
+    ) -> Union["HeteroGraphDataset", HeteroGraphData]:
+        indices = range(len(self))
+
+        if isinstance(idx, (int, np.integer)) or (
+            isinstance(idx, mx.array) and idx.ndim == 0  # type: ignore
+        ):
+            index = indices[idx]  # type:ignore - idx here is a singleton
+            data = self.graphs[index]
+
+            if self.transform is not None:
+                data = self.transform(data)
+
+            return data
+
+        if isinstance(idx, slice):
+            indices = indices[idx]
+
+        elif isinstance(idx, mx.array) and idx.dtype in [  # type: ignore
+            mx.int64,
+            mx.int32,
+            mx.int16,
+        ]:
+            return self[idx.flatten().tolist()]  # type: ignore - idx is a mx.array
+
+        elif isinstance(idx, np.ndarray) and idx.dtype == np.int64:
+            return self[idx.flatten().tolist()]
+
+        elif isinstance(idx, Sequence) and not isinstance(idx, str):
+            indices = [indices[i] for i in idx]
+
+        else:
+            raise IndexError(
+                f"HeteroGraphDataset indexing failed."
+                f"Accepted indices are: int, mx.array,"
+                f"list, tuple, np.ndarray (got '{type(idx).__name__}')"
+            )
+
+        dataset = copy.copy(self)
+        graphs = [self.graphs[i] for i in indices]
+        if self.transform is not None:
+            graphs = [self.transform(g) for g in graphs]
+        dataset.graphs = graphs
+        return dataset

--- a/mlx_graphs/datasets/hetero_dataset.py
+++ b/mlx_graphs/datasets/hetero_dataset.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Callable, Literal, Optional, Sequence, Union
+from typing import Any, Callable, Literal, Optional, Sequence, Union
 
 import mlx.core as mx
 import numpy as np
@@ -11,7 +11,7 @@ from mlx_graphs.datasets import BaseDataset
 DEFAULT_BASE_DIR = os.path.join(os.getcwd(), ".mlx_graphs_data/")
 
 
-class HeteroGraphDataset(BaseDataset):
+class HeteroDataset(BaseDataset):
     def __init__(
         self,
         name: str,
@@ -23,7 +23,7 @@ class HeteroGraphDataset(BaseDataset):
         self._base_dir = base_dir if base_dir else DEFAULT_BASE_DIR
         self.transform = transform
         self.pre_transform = pre_transform
-        self.graphs: Union[list[HeteroGraphData]] = []
+        self.graphs: list[HeteroGraphData] = []
         self._load()
 
     @property
@@ -47,7 +47,7 @@ class HeteroGraphDataset(BaseDataset):
         return self.graphs[0].num_node_classes
 
     @property
-    def num_edge_classes(self) -> dict[str, int]:
+    def num_edge_classes(self) -> dict[Any, int]:
         """Returns a dictionary of the number of edge classes for each edge type."""
         return self.graphs[0].num_edge_classes
 
@@ -57,11 +57,13 @@ class HeteroGraphDataset(BaseDataset):
         return self.graphs[0].num_nodes
 
     @property
-    def num_edges(self) -> dict[str, int]:
+    def num_edges(self) -> dict[Any, int]:
         """Returns a dictionary of the number of edges for each edge type."""
         return self.graphs[0].num_edges
 
-    def _num_classes(self, task: Literal["node", "edge", "graph"]) -> dict[str, int]:
+    def _num_classes(
+        self, task: Literal["node", "edge", "graph"]
+    ) -> Union[dict[str, int], int]:
         num_classes_dict = {}
         for g in self.graphs:
             if task == "node":
@@ -99,7 +101,7 @@ class HeteroGraphDataset(BaseDataset):
     def __getitem__(
         self,
         idx: Union[int, np.integer, slice, mx.array, np.ndarray, Sequence],
-    ) -> Union["HeteroGraphDataset", HeteroGraphData]:
+    ) -> Union["HeteroDataset", HeteroGraphData]:
         indices = range(len(self))
 
         if isinstance(idx, (int, np.integer)) or (

--- a/mlx_graphs/datasets/hetero_dataset.py
+++ b/mlx_graphs/datasets/hetero_dataset.py
@@ -1,17 +1,30 @@
 import copy
-import os
 from typing import Any, Callable, Literal, Optional, Sequence, Union
 
 import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import HeteroGraphData
-from mlx_graphs.datasets import BaseDataset
-
-DEFAULT_BASE_DIR = os.path.join(os.getcwd(), ".mlx_graphs_data/")
+from mlx_graphs.datasets.base_dataset import DEFAULT_BASE_DIR, BaseDataset
 
 
 class HeteroDataset(BaseDataset):
+    """
+    A dataset class for handling heterogeneous graph data.
+
+    Args:
+        name: name of the dataset
+        base_dir: Directory where to store dataset files. Default is
+            in the local directory ``.mlx_graphs_data/``.
+        pre_transform: A function/transform that takes in a ``HeteroGraphData`` object
+            and returns a transformed version. The transformation is applied before
+            the first access.
+        transform: A function/transform that takes in a ``HeteroGraphData`` object and
+            returns a transformed version. The transformation is applied before every
+            access, i.e., during the ``__getitem__`` call.
+            By default, no transformation is applied.
+    """
+
     def __init__(
         self,
         name: str,

--- a/mlx_graphs/datasets/imdb.py
+++ b/mlx_graphs/datasets/imdb.py
@@ -7,11 +7,11 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import HeteroGraphData
-from mlx_graphs.datasets import HeteroGraphDataset
+from mlx_graphs.datasets import HeteroDataset
 from mlx_graphs.datasets.utils import download, extract_archive
 
 
-class IMDB(HeteroGraphDataset):
+class IMDB(HeteroDataset):
     """
     A subset of the Internet Movie Database (IMDB), as collected in the
     `"MAGNN: Metapath Aggregated Graph Neural Network for Heterogeneous Graph
@@ -98,7 +98,7 @@ class IMDB(HeteroGraphDataset):
         for name in ["train", "val", "test"]:
             idx = split[f"{name}_idx"]
             idx = mx.array(idx, dtype=mx.int64)
-            mask = mx.zeros(data.num_nodes["movie"], dtype=mx.bool_)
+            mask = mx.zeros(data.num_nodes["movie"], dtype=mx.bool_)  # type: ignore
             mask[idx] = True
             setattr(data, f"movie_{name}_mask", mask)
         s = {}

--- a/mlx_graphs/datasets/imdb.py
+++ b/mlx_graphs/datasets/imdb.py
@@ -7,11 +7,11 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import HeteroGraphData
-from mlx_graphs.datasets.dataset import Dataset
+from mlx_graphs.datasets import HeteroGraphDataset
 from mlx_graphs.datasets.utils import download, extract_archive
 
 
-class IMDB(Dataset):
+class IMDB(HeteroGraphDataset):
     """
     A subset of the Internet Movie Database (IMDB), as collected in the
     `"MAGNN: Metapath Aggregated Graph Neural Network for Heterogeneous Graph

--- a/mlx_graphs/datasets/imdb.py
+++ b/mlx_graphs/datasets/imdb.py
@@ -81,7 +81,7 @@ class IMDB(HeteroGraphDataset):
         node_types = ["movie", "director", "actor"]
         for i, node_type in enumerate(node_types):
             nodes = sp.load_npz(osp.join(self.raw_path, f"features_{i}.npz"))
-            node_features_dict[node_type] = mx.array(nodes.todense())
+            node_features_dict[node_type] = mx.array(nodes.todense()).astype(mx.float32)
 
         node_labels_dict = {}
         y = np.load(osp.join(self.raw_path, "labels.npy"))

--- a/mlx_graphs/datasets/movie_lens_100k.py
+++ b/mlx_graphs/datasets/movie_lens_100k.py
@@ -6,11 +6,11 @@ import mlx.core as mx
 import numpy as np
 
 from mlx_graphs.data import HeteroGraphData
-from mlx_graphs.datasets.dataset import Dataset
+from mlx_graphs.datasets import HeteroGraphDataset
 from mlx_graphs.datasets.utils import download, extract_archive
 
 
-class MovieLens100K(Dataset):
+class MovieLens100K(HeteroGraphDataset):
     """
     The MovieLens 100K heterogeneous rating dataset, assembled by GroupLens
     Research from the `MovieLens web site <https://movielens.org>`__,

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from mlx_graphs.data.data import GraphData, HeteroGraphData
-from mlx_graphs.datasets.dataset import Dataset
+from mlx_graphs.datasets import Dataset, HeteroGraphDataset
 
 
 def test_fake_dataset():
@@ -101,7 +101,7 @@ def test_dataset_properties_hetero_graph_data(tmp_path):
         graph_labels=mx.array([1]),
     )
 
-    class HeteroGraphDataSet(Dataset):
+    class HeteroGraphDataSet(HeteroGraphDataset):
         def __init__(self):
             super().__init__("HeteroGraphDataSet", base_dir=tmp_path)
 

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from mlx_graphs.data.data import GraphData, HeteroGraphData
-from mlx_graphs.datasets import Dataset, HeteroGraphDataset
+from mlx_graphs.datasets import Dataset, HeteroDataset
 
 
 def test_fake_dataset():
@@ -101,7 +101,7 @@ def test_dataset_properties_hetero_graph_data(tmp_path):
         graph_labels=mx.array([1]),
     )
 
-    class HeteroGraphDataSet(HeteroGraphDataset):
+    class HeteroGraphDataSet(HeteroDataset):
         def __init__(self):
             super().__init__("HeteroGraphDataSet", base_dir=tmp_path)
 

--- a/tests/datasets/test_tu_dataset.py
+++ b/tests/datasets/test_tu_dataset.py
@@ -13,7 +13,7 @@ def test_tu_dataset(tmp_path):
     dataset_name = "ENZYMES"
 
     dataset = TUDataset(dataset_name, base_dir=tmp_path)
-    dataset_torch = TUDataset_torch(tmp_path, dataset_name)
+    dataset_torch = TUDataset_torch(tmp_path, dataset_name, use_node_attr=True)
 
     train_loader = Dataloader(dataset, 10, shuffle=False)
     train_loader_torch = DataLoader(dataset_torch, 10, shuffle=False)
@@ -26,11 +26,6 @@ def test_tu_dataset(tmp_path):
         if batch_mxg.node_features is not None:
             assert mx.array_equal(
                 mx.array(batch_pyg.x.tolist()), batch_mxg.node_features
-            ), "Two arrays between PyG and mxg are different"
-
-        if batch_mxg.graph_labels is not None:
-            assert mx.array_equal(
-                mx.array(batch_pyg.y.tolist()), batch_mxg.graph_labels
             ), "Two arrays between PyG and mxg are different"
 
         if batch_mxg.graph_labels is not None:


### PR DESCRIPTION
Added new dataset class for Heterograph data

1. Type errors in IMDB and DBLP tests are occurring because the 'Dataset' placeholder is being used to represent both 'HeteroGraphData' and 'GraphData' types.`
2.  Replaced IMDB and DBLP datasets with HeteroGraph dataset to resolve the type errors

## Proposed changes

Please include a description of the problem or feature this PR is addressing.
If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation
