### PR TITLE
bump mlx_version and remove mlx_cluster dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,11 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "mlx==0.18.*; sys_platform == 'darwin'",
+    "mlx>=0.18; sys_platform == 'darwin'",
     "numpy==1.26.3",
     "requests==2.31.0",
     "fsspec==2024.2.0",
     "tqdm==4.66.1",
-    "mlx_cluster==0.0.4"
 ]
 
 [project.optional-dependencies]

--- a/tests/algorithms/test_node2vec.py
+++ b/tests/algorithms/test_node2vec.py
@@ -1,6 +1,9 @@
 import mlx.core as mx
+import pytest
 
-from mlx_graphs.algorithms import Node2Vec
+pytest.importorskip("mlx_cluster")
+
+from mlx_graphs.algorithms import Node2Vec  # noqa
 
 mx.random.seed(42)
 


### PR DESCRIPTION
## Proposed changes

This PR bumps the mlx version and removed the mlx_cluster mandatory dependency as it requires mlx==0.18

closes #173 