### PR TITLE
Add Gatv2 - "How Attentive are Graph Attention Networks?"

### DIFF
--- a/docs/source/api/algorithms/index.rst
+++ b/docs/source/api/algorithms/index.rst
@@ -1,4 +1,4 @@
-.. _datasetslgorithms:
+.. _algorithms:
 
 Algorithms
 ==========
@@ -10,4 +10,4 @@ Algorithms
 	:toctree: _autosummary
 	:template: custom-class-template.rst
 
-	Node2Vec
+	.. Node2Vec

--- a/docs/source/api/nn/index.rst
+++ b/docs/source/api/nn/index.rst
@@ -15,6 +15,7 @@ Neural Networks
 	GraphNetworkBlock
 	SimpleConv
 	GATConv
+	GATv2Conv
 	GCNConv
 	GINConv
 	SAGEConv

--- a/examples/dictionary_lookup.py
+++ b/examples/dictionary_lookup.py
@@ -1,209 +1,219 @@
-import mlx.core as mx
-import mlx.nn as nn 
-import mlx.optimizers as optim 
 import itertools
-from mlx_graphs.nn import GATv2Conv, GATConv
-import random 
-import math 
-from typing import Iterator  
-import numpy as np  
+import math
+import random
+from typing import Iterator
 
-""" 
-Testing the Dictionary Lookup synthetic problem from 4.1 "Synthetic Benchmark: DictionaryLookup" in "How Attentive Are Graph Attention Networks?"
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+import numpy as np
 
-Minimal version based off of https://github.com/tech-srl/how_attentive_are_gats to showcase dramatic difference in accuracy 
+from mlx_graphs.nn import GATConv, GATv2Conv
+
+"""
+Dictionary Lookup problem "Synthetic Benchmark: DictionaryLookup"
+    from "How Attentive Are Graph Attention Networks?"
+
+Minimal version based off of https://github.com/tech-srl/how_attentive_are_gats
+    but modified to showcase difference in accuracy from GATConv to GATv2Conv
 """
 
 
 class Model(nn.Module):
-
-    def __init__(self, k: int, hidden_states: int = 128, dynamic_attention : bool = True):
+    def __init__(
+        self, k: int, hidden_states: int = 128, dynamic_attention: bool = True
+    ):
         super().__init__()
-        self.k = k 
+        self.k = k
         self.hidden_states = hidden_states
         self.dynamic_attention = dynamic_attention
 
-        # +1 corresponds to "empty" for keys 
+        # +1 corresponds to "empty" for keys
         self.keys0 = nn.Embedding(k + 1, self.hidden_states)
         self.values0 = nn.Embedding(k + 1, self.hidden_states)
         self.ff0 = nn.Sequential(nn.ReLU())
 
         if self.dynamic_attention:
-            self.gnn = GATv2Conv(self.hidden_states, self.hidden_states, heads = 1)
-        else: 
-            self.gnn = GATConv(self.hidden_states, self.hidden_states, heads = 1)
+            self.gnn = GATv2Conv(self.hidden_states, self.hidden_states, heads=1)
+        else:
+            self.gnn = GATConv(self.hidden_states, self.hidden_states, heads=1)
 
         self.ffn = nn.Linear(self.hidden_states, k)
 
-    def __call__(self, edges: mx.array, nodes: mx.array):  
+    def __call__(self, edges: mx.array, nodes: mx.array):
         x_key, x_val = nodes[:, 0], nodes[:, 1]
         x_key_embed = self.keys0(x_key)
         x_val_embed = self.values0(x_val)
 
-        x = x_key_embed + x_val_embed 
+        x = x_key_embed + x_val_embed
         x = self.ff0(x)
 
-        # We only need the attribute row in the keys. 
-        out = self.gnn(edges, x)[:self.k, :]
+        # We only need the attribute row in the keys.
+        out = self.gnn(edges, x)[: self.k, :]
         return self.ffn(out)
 
-class DictionaryLookupDataset(object): 
-    def __init__(self, k: int, max_examples: int = 32_000): 
+
+class DictionaryLookupDataset(object):
+    def __init__(self, k: int, max_examples: int = 32_000):
         super().__init__()
 
-        self.k = k 
-        self.max_examples = max_examples 
+        self.k = k
+        self.max_examples = max_examples
         # Empty id is for representing query nodes
-        self.edges, self.empty_id = self.init_edges() 
+        self.edges, self.empty_id = self.init_edges()
 
-    def init_edges(self) -> tuple[list, int]: 
+    def init_edges(self) -> tuple[list, int]:
         targets = range(0, self.k)
         sources = range(self.k, self.k * 2)
 
-        # Complete Bipartite Graph 
-        next_unused_id = self.k 
+        # Complete Bipartite Graph
+        next_unused_id = self.k
         all_pairs = itertools.product(sources, targets)
         edges = [list(i) for i in zip(*all_pairs)]
 
         return edges, next_unused_id
 
     def create_empty_graph(self) -> mx.array:
-        edge_index = mx.array(self.edges, dtype = mx.int64)
+        edge_index = mx.array(self.edges, dtype=mx.int64)
         return edge_index
 
     def get_permutations(self) -> list[list]:
         limit = math.factorial(self.k)
 
-        # Apply a hard limit of the factorial size is too big 
-        if limit <= self.max_examples: 
+        # Apply a hard limit of the factorial size is too big
+        if limit <= self.max_examples:
             generator = itertools.permutations(range(self.k))
             return [perm for _, perm in zip(range(limit), generator)]
-        else: 
-            return [np.random.permutation(range(self.k)).tolist() for _ in range(self.max_examples)]
+        else:
+            return [
+                np.random.permutation(range(self.k)).tolist()
+                for _ in range(self.max_examples)
+            ]
 
-    def get_graphs(self) -> list[tuple[mx.array, mx.array]]: 
-        graphs = [] 
-        for permutation in self.get_permutations(): 
+    def get_graphs(self) -> list[tuple[mx.array, mx.array]]:
+        graphs = []
+        for permutation in self.get_permutations():
             edge_index = self.create_empty_graph()
-            nodes = mx.array(self.get_nodes_features(permutation), dtype = mx.int64)
+            nodes = mx.array(self.get_nodes_features(permutation), dtype=mx.int64)
             graphs.append((edge_index, nodes))
-        return graphs 
-    
-    def get_nodes_features(self, perm) -> list[tuple[int, int]]: 
+        return graphs
+
+    def get_nodes_features(self, perm) -> list[tuple[int, int]]:
         # Query Nodes
         nodes = [(key, self.empty_id) for key in range(self.k)]
         # Key Nodes
-        for key, val in zip(range(self.k), perm): 
+        for key, val in zip(range(self.k), perm):
             nodes.append((key, val))
-        
-        return nodes 
 
-def loss_fn(model, X: list[tuple[mx.array, mx.array]]): 
+        return nodes
 
-    logit_list = [] 
-    value_list = [] 
-    for (e, n) in X: 
+
+def loss_fn(model, X: list[tuple[mx.array, mx.array]]):
+    logit_list = []
+    value_list = []
+    for e, n in X:
         logits = model(e, n)
-        # Get the attribute row in keys 
-        values = n[model.k:, 1]
+        # Get the attribute row in keys
+        values = n[model.k :, 1]
 
         logit_list.append(logits)
         value_list.append(values)
 
-    logit_list = mx.concat(logit_list, axis = 0)
-    value_list = mx.concat(value_list, axis = 0)
+    logit_list = mx.concat(logit_list, axis=0)
+    value_list = mx.concat(value_list, axis=0)
 
     loss = nn.losses.cross_entropy(logit_list, value_list).mean()
-    return loss     
+    return loss
+
 
 def eval_fn(model, X: tuple[mx.array, mx.array]):
     logits = model(X[0], X[1])
-    pred = logits.argmax(axis = 1)
+    pred = logits.argmax(axis=1)
 
-    true = X[1][model.k:, 1]
+    true = X[1][model.k :, 1]
 
-    return pred, true 
+    return pred, true
+
 
 def handle_model(
-        model, 
-        train_graphs: list, 
-        test_graphs: list, 
-        epochs: int = 1000,
-        batch_size: int = 256,
-        learning_rate: float = 0.001, 
-        warmup_steps: int = 40) -> Iterator[float]:
+    model,
+    train_graphs: list,
+    test_graphs: list,
+    epochs: int = 1000,
+    batch_size: int = 256,
+    learning_rate: float = 0.001,
+    warmup_steps: int = 40,
+) -> Iterator[float]:
     mx.eval(model.parameters())
 
     step_size = int(len(train_graphs) / batch_size)
 
-    warmup = optim.linear_schedule(0, learning_rate, steps = warmup_steps * step_size)
+    warmup = optim.linear_schedule(0, learning_rate, steps=warmup_steps * step_size)
     decay = optim.step_decay(learning_rate, 0.95, step_size * 20)
     lr_schedule = optim.join_schedules([warmup, decay], [warmup_steps * step_size])
 
-    optimizer = optim.Adam(learning_rate = lr_schedule)
+    optimizer = optim.Adam(learning_rate=lr_schedule)
     loss_and_grad_fn = nn.value_and_grad(model, loss_fn)
-    for _ in range(epochs): 
-
-        # Train Step 
-        for i in range(0, len(train_graphs), batch_size): 
+    for _ in range(epochs):
+        # Train Step
+        for i in range(0, len(train_graphs), batch_size):
             loss, grads = loss_and_grad_fn(model, train_graphs[i : i + batch_size])
             optimizer.update(model, grads)
             mx.eval(model.parameters(), optimizer.state)
 
-
-        # Eval Step 
-        preds = [] 
-        trues = [] 
-        for (edge_index, nodes) in test_graphs: 
+        # Eval Step
+        preds = []
+        trues = []
+        for edge_index, nodes in test_graphs:
             pred, true = eval_fn(model, (edge_index, nodes))
 
             preds.append(pred)
             trues.append(true)
 
-        preds = mx.concat(preds, axis = 0)
-        trues = mx.concat(trues, axis = 0)
+        preds = mx.concat(preds, axis=0)
+        trues = mx.concat(trues, axis=0)
 
-        acc = ((preds == trues).sum() / preds.shape[0])
+        acc = (preds == trues).sum() / preds.shape[0]
         yield acc
-            
 
-def run_example(): 
+
+def run_example():
     np.random.seed(42)
     mx.random.seed(42)
 
     k = 12
-    train_size = 0.8 
-    epochs = 1000 
+    train_size = 0.8
+    epochs = 1000
     batch_size = 256
 
     dataset = DictionaryLookupDataset(k)
 
-    modelv1 = Model(k, dynamic_attention = False)
-    modelv2 = Model(k, dynamic_attention = True)
+    modelv1 = Model(k, dynamic_attention=False)
+    modelv2 = Model(k, dynamic_attention=True)
 
     graphs = dataset.get_graphs()
     random.shuffle(graphs)
 
-    train = graphs[:int(len(graphs) * train_size)]
-    test = graphs[int(len(graphs) * train_size):]
+    train = graphs[: int(len(graphs) * train_size)]
+    test = graphs[int(len(graphs) * train_size) :]
 
-    i = 1 
-    accuracies = [] 
+    i = 1
+    accuracies = []
     for accv1, accv2 in zip(
-            handle_model(modelv1, train, test, epochs, batch_size), 
-            handle_model(modelv2, train, test, epochs, batch_size)):
-        
+        handle_model(modelv1, train, test, epochs, batch_size),
+        handle_model(modelv2, train, test, epochs, batch_size),
+    ):
         print("Epoch {}: GATv1: {:0.2%} GATv2: {:0.2%}".format(i, accv1, accv2))
         accuracies.append(accv2)
 
         if math.isclose(accv2, 1.0):
             print("GATv2 reached maximum accuracy in {} epochs".format(i))
             break
-        
-        # Early stopping if no improvement 
-        if len(accuracies) >= 10 and np.all(np.diff(np.array(accuracies[-10:])) <= 0): 
+
+        # Early stopping if no improvement
+        if len(accuracies) >= 10 and np.all(np.diff(np.array(accuracies[-10:])) <= 0):
             print("Stopping due to no accuracy improvements")
-            break 
+            break
         i += 1
 
 

--- a/examples/dictionary_lookup.py
+++ b/examples/dictionary_lookup.py
@@ -1,0 +1,197 @@
+import mlx.core as mx
+import mlx.nn as nn 
+import mlx.optimizers as optim 
+import itertools
+from mlx_graphs.nn import GATv2Conv, GATConv
+import random 
+import math 
+from typing import Iterator  
+import numpy as np  
+
+""" 
+Testing the Dictionary Lookup synthetic problem from 4.1 "Synthetic Benchmark: DictionaryLookup" in "How Attentive Are Graph Attention Networks?"
+
+Minimal version based off of https://github.com/tech-srl/how_attentive_are_gats to showcase dramatic difference in accuracy 
+"""
+
+
+class Model(nn.Module):
+
+    def __init__(self, k: int, hidden_states: int = 128, dynamic_attention : bool = True):
+        super().__init__()
+        self.k = k 
+        self.hidden_states = hidden_states
+        self.dynamic_attention = dynamic_attention
+
+        # +1 corresponds to "empty" for keys 
+        self.keys0 = nn.Embedding(k + 1, self.hidden_states)
+        self.values0 = nn.Embedding(k + 1, self.hidden_states)
+        self.ff0 = nn.Sequential(nn.ReLU())
+
+        if self.dynamic_attention:
+            self.gnn = GATv2Conv(self.hidden_states, self.hidden_states, heads = 1)
+        else: 
+            self.gnn = GATConv(self.hidden_states, self.hidden_states, heads = 1)
+
+        self.ffn = nn.Linear(self.hidden_states, k)
+
+    def __call__(self, edges: mx.array, nodes: mx.array):  
+        x_key, x_val = nodes[:, 0], nodes[:, 1]
+        x_key_embed = self.keys0(x_key)
+        x_val_embed = self.values0(x_val)
+
+        x = x_key_embed + x_val_embed 
+        x = self.ff0(x)
+
+        # We only need the attribute row in the keys. 
+        out = self.gnn(edges, x)[:self.k, :]
+        return self.ffn(out)
+
+class DictionaryLookupDataset(object): 
+    def __init__(self, k: int, max_examples: int = 32_000): 
+        super().__init__()
+
+        self.k = k 
+        self.max_examples = max_examples 
+        # Empty id is for representing query nodes
+        self.edges, self.empty_id = self.init_edges() 
+
+    def init_edges(self) -> tuple[list, int]: 
+        targets = range(0, self.k)
+        sources = range(self.k, self.k * 2)
+
+        # Complete Bipartite Graph 
+        next_unused_id = self.k 
+        all_pairs = itertools.product(sources, targets)
+        edges = [list(i) for i in zip(*all_pairs)]
+
+        return edges, next_unused_id
+
+    def create_empty_graph(self) -> mx.array:
+        edge_index = mx.array(self.edges, dtype = mx.int64)
+        return edge_index
+
+    def get_permutations(self) -> list[list]:
+        limit = math.factorial(self.k)
+
+        # Apply a hard limit of the factorial size is too big 
+        if limit <= self.max_examples: 
+            generator = itertools.permutations(range(self.k))
+            return [perm for _, perm in zip(range(limit), generator)]
+        else: 
+            return [np.random.permutation(range(self.k)).tolist() for _ in range(self.max_examples)]
+
+    def get_graphs(self) -> list[tuple[mx.array, mx.array]]: 
+        graphs = [] 
+        for permutation in self.get_permutations(): 
+            edge_index = self.create_empty_graph()
+            nodes = mx.array(self.get_nodes_features(permutation), dtype = mx.int64)
+            graphs.append((edge_index, nodes))
+        return graphs 
+    
+    def get_nodes_features(self, perm) -> list[tuple[int, int]]: 
+        # Query Nodes
+        nodes = [(key, self.empty_id) for key in range(self.k)]
+        # Key Nodes
+        for key, val in zip(range(self.k), perm): 
+            nodes.append((key, val))
+        
+        return nodes 
+
+def loss_fn(model, X: list[tuple[mx.array, mx.array]]): 
+
+    logit_list = [] 
+    value_list = [] 
+    for (e, n) in X: 
+        logits = model(e, n)
+        # Get the attribute row in keys 
+        values = n[model.k:, 1]
+
+        logit_list.append(logits)
+        value_list.append(values)
+
+    logit_list = mx.concat(logit_list, axis = 0)
+    value_list = mx.concat(value_list, axis = 0)
+
+    loss = nn.losses.cross_entropy(logit_list, value_list).mean()
+    return loss     
+
+def eval_fn(model, X: tuple[mx.array, mx.array]):
+    logits = model(X[0], X[1])
+    pred = logits.argmax(axis = 1)
+
+    true = X[1][model.k:, 1]
+
+    return pred, true 
+
+def handle_model(
+        model, 
+        train_graphs: list, 
+        test_graphs: list, 
+        epochs: int = 5,
+        batch_size: int = 256,
+        learning_rate = 0.001) -> Iterator[float]:
+    mx.eval(model.parameters())
+
+    warmup_steps = int(epochs * 0.1)
+
+    step_size = int(len(train_graphs) / batch_size)
+
+    warmup = optim.linear_schedule(0, learning_rate, steps = warmup_steps * step_size)
+    decay = optim.cosine_decay(learning_rate, epochs * step_size)
+    lr_schedule = optim.join_schedules([warmup, decay], [warmup_steps * step_size])
+
+    optimizer = optim.Adam(learning_rate = lr_schedule)
+    loss_and_grad_fn = nn.value_and_grad(model, loss_fn)
+    for _ in range(epochs): 
+
+        # Train Step 
+        for i in range(0, len(train_graphs), batch_size): 
+            loss, grads = loss_and_grad_fn(model, train_graphs[i : i + batch_size])
+            optimizer.update(model, grads)
+            mx.eval(model.parameters(), optimizer.state)
+
+
+        # Eval Step 
+        preds = [] 
+        trues = [] 
+        for (edge_index, nodes) in test_graphs: 
+            pred, true = eval_fn(model, (edge_index, nodes))
+
+            preds.append(pred)
+            trues.append(true)
+
+        preds = mx.concat(preds, axis = 0)
+        trues = mx.concat(trues, axis = 0)
+
+        acc = ((preds == trues).sum() / preds.shape[0])
+        yield acc
+            
+
+def run_example(): 
+    k = 12
+    train_size = 0.8 
+    epochs = 1000 
+    batch_size = 256
+
+    dataset = DictionaryLookupDataset(k)
+
+    modelv1 = Model(k, dynamic_attention = False)
+    modelv2 = Model(k, dynamic_attention = True)
+
+    graphs = dataset.get_graphs()
+    random.shuffle(graphs)
+
+    train = graphs[:int(len(graphs) * train_size)]
+    test = graphs[int(len(graphs) * train_size):]
+
+    i = 1 
+    for accv1, accv2 in zip(
+            handle_model(modelv1, train, test, epochs, batch_size), 
+            handle_model(modelv2, train, test, epochs, batch_size)):
+        
+        print("Epoch {}: GATv1: {:0.2%} GATv2: {:0.2%}".format(i, accv1, accv2))
+        i += 1
+
+if __name__ == "__main__":
+    run_example()

--- a/mlx_graphs/nn/conv/__init__.py
+++ b/mlx_graphs/nn/conv/__init__.py
@@ -1,5 +1,5 @@
 from .gat_conv import GATConv  # noqa
-from .gatv2_conf import GATv2Conv
+from .gatv2_conf import GATv2Conv  # noqa
 from .gcn_conv import GCNConv  # noqa
 from .gin_conv import GINConv  # noqa
 from .sage_conv import SAGEConv  # noqa

--- a/mlx_graphs/nn/conv/__init__.py
+++ b/mlx_graphs/nn/conv/__init__.py
@@ -1,4 +1,5 @@
 from .gat_conv import GATConv  # noqa
+from .gatv2_conf import GATv2Conv
 from .gcn_conv import GCNConv  # noqa
 from .gin_conv import GINConv  # noqa
 from .sage_conv import SAGEConv  # noqa

--- a/mlx_graphs/nn/conv/gatv2_conf.py
+++ b/mlx_graphs/nn/conv/gatv2_conf.py
@@ -1,17 +1,18 @@
-from typing import Optional 
+from typing import Optional
 
-import mlx.core as mx 
-import mlx.nn as nn 
+import mlx.core as mx
+import mlx.nn as nn
 
-from mlx_graphs.nn.linear import Linear 
+from mlx_graphs.nn.linear import Linear
 from mlx_graphs.nn.message_passing import MessagePassing
-from mlx_graphs.utils import get_src_dst_features, scatter 
+from mlx_graphs.utils import get_src_dst_features, scatter
+
 
 class GATv2Conv(MessagePassing):
-    """Graph Attention Network convolution layer with dynamic attention. 
+    """Graph Attention Network convolution layer with dynamic attention.
 
     Modification of GATConv based off of "How Attentive are Graph Attention Networks"
-    
+
     Args:
         node_features_dim: Size of input node features
         out_features_dim: Size of output node embeddings
@@ -38,16 +39,16 @@ class GATv2Conv(MessagePassing):
     """
 
     def __init__(
-            self,
-            node_features_dim: int, 
-            out_features_dim: int, 
-            heads: int = 1, 
-            concat: bool = True, 
-            bias: bool = True, 
-            negative_slope: float = 0.2, 
-            dropout: float = 0.0,
-            edge_features_dim: Optional[int] = None, 
-            **kwargs, 
+        self,
+        node_features_dim: int,
+        out_features_dim: int,
+        heads: int = 1,
+        concat: bool = True,
+        bias: bool = True,
+        negative_slope: float = 0.2,
+        dropout: float = 0.0,
+        edge_features_dim: Optional[int] = None,
+        **kwargs,
     ):
         kwargs.setdefault("aggr", "add")
         super(GATv2Conv, self).__init__(**kwargs)
@@ -57,11 +58,11 @@ class GATv2Conv(MessagePassing):
         self.concat = concat
         self.negative_slope = negative_slope
 
-        # Weights 
-        self.W_src = Linear(node_features_dim, heads * out_features_dim, bias = False)
-        self.W_dst = Linear(node_features_dim, heads * out_features_dim, bias = False)
+        # Weights
+        self.W_src = Linear(node_features_dim, heads * out_features_dim, bias=False)
+        self.W_dst = Linear(node_features_dim, heads * out_features_dim, bias=False)
 
-        # Attention is applied in message() during message passing stage. 
+        # Attention is applied in message() during message passing stage.
         glorot_init = nn.init.glorot_uniform()
         self.att = glorot_init(mx.zeros((1, heads, out_features_dim)))
 
@@ -103,14 +104,14 @@ class GATv2Conv(MessagePassing):
         dst_idx = edge_index[1]
 
         node_features = self.propagate(
-            node_features = (src_feats, dst_feats),
-            edge_index = edge_index, 
-            message_kwargs = {
-                "src" : src, 
-                "dst" : dst, 
-                "index" : dst_idx,
-                "edge_features" : edge_features
-            }
+            node_features=(src_feats, dst_feats),
+            edge_index=edge_index,
+            message_kwargs={
+                "src": src,
+                "dst": dst,
+                "index": dst_idx,
+                "edge_features": edge_features,
+            },
         )
 
         if self.concat:
@@ -126,32 +127,31 @@ class GATv2Conv(MessagePassing):
         return node_features
 
     def message(
-        self, 
-        src_features: mx.array, 
-        dst_features: mx.array, 
-        src: mx.array, 
-        dst: mx.array, 
-        index: mx.array, 
-        edge_features: Optional[mx.array] = None, 
+        self,
+        src_features: mx.array,
+        dst_features: mx.array,
+        src: mx.array,
+        dst: mx.array,
+        index: mx.array,
+        edge_features: Optional[mx.array] = None,
     ) -> mx.array:
-
-        # Collect alpha before applying non-linearity 
-        alpha = src + dst 
-        if edge_features is not None: 
+        # Collect alpha before applying non-linearity
+        alpha = src + dst
+        if edge_features is not None:
             alpha_edge = self._compute_edge_features(edge_features)
             alpha = alpha + alpha_edge
 
         alpha = nn.leaky_relu(alpha, self.negative_slope)
-        # Apply attention after non-linearity to get dynamic attention 
+        # Apply attention after non-linearity to get dynamic attention
         alpha = (alpha * self.att).sum(-1)
 
-        alpha = scatter(alpha, index, self.num_nodes, aggr = "softmax")
+        alpha = scatter(alpha, index, self.num_nodes, aggr="softmax")
 
-        if "dropout" in self: 
+        if "dropout" in self:
             alpha = self.dropout(alpha)
 
-        return mx.expand_dims(alpha, - 1) * src_features
-        
+        return mx.expand_dims(alpha, -1) * src_features
+
     def _compute_edge_features(self, edge_features: mx.array):
         assert all(layer in self for layer in ["edge_lin_proj", "edge_att"]), """Using
         edge features, GATConv layer should be provided argument
@@ -164,5 +164,3 @@ class GATv2Conv(MessagePassing):
         edge_features = edge_features.reshape(-1, self.heads, self.out_features_dim)
 
         return edge_features
-
-    

--- a/mlx_graphs/nn/conv/gatv2_conf.py
+++ b/mlx_graphs/nn/conv/gatv2_conf.py
@@ -1,0 +1,141 @@
+from typing import Optional 
+
+import mlx.core as mx 
+import mlx.nn as nn 
+
+from mlx_graphs.nn.linear import Linear 
+from mlx_graphs.nn.message_passing import MessagePassing
+from mlx_graphs.utils import get_src_dst_features, scatter 
+
+class GATv2Conv(MessagePassing):
+    """Graph Attention Network convolution layer with dynamic attention. 
+    
+    """
+
+    def __init__(
+            self,
+            node_features_dim: int, 
+            out_features_dim: int, 
+            heads: int = 1, 
+            concat: bool = True, 
+            bias: bool = True, 
+            negative_slope: float = 0.2, 
+            dropout: float = 0.0,
+            edge_features_dim: Optional[int] = None, 
+            **kwargs, 
+    ):
+        kwargs.setdefault("aggr", "add")
+        super(GATv2Conv, self).__init__(**kwargs)
+
+        self.out_features_dim = out_features_dim
+        self.heads = heads
+        self.concat = concat
+        self.negative_slope = negative_slope
+
+        self.W_src = Linear(node_features_dim, heads * out_features_dim, bias = False)
+        self.W_dst = Linear(node_features_dim, heads * out_features_dim, bias = False)
+
+        glorot_init = nn.init.glorot_uniform()
+        self.att = glorot_init(mx.zeros((1, heads, out_features_dim)))
+
+        if bias:
+            bias_shape = (heads * out_features_dim) if concat else (out_features_dim)
+            self.bias = mx.zeros(bias_shape)
+
+        if dropout > 0.0:
+            self.dropout = nn.Dropout(dropout)
+
+        if edge_features_dim is not None:
+            self.edge_lin_proj = Linear(
+                edge_features_dim, heads * out_features_dim, bias=False
+            )
+            self.edge_att = glorot_init(mx.zeros((1, heads, out_features_dim)))
+
+    def __call__(
+        self,
+        edge_index: mx.array,
+        node_features: mx.array,
+        edge_features: Optional[mx.array] = None,
+    ) -> mx.array:
+        """Computes the forward pass of GATConv.
+
+        Args:
+            edge_index: input edge index of shape `[2, num_edges]`
+            node_features: input node features
+            edge_features: edge features
+
+        Returns:
+            mx.array: computed node embeddings
+        """
+        H, C = self.heads, self.out_features_dim
+
+        src_feats = self.W_src(node_features).reshape(-1, H, C)
+        dst_feats = self.W_dst(node_features).reshape(-1, H, C)
+
+        src, dst = get_src_dst_features(edge_index, (src_feats, dst_feats))
+        dst_idx = edge_index[1]
+
+        node_features = self.propagate(
+            node_features = (src_feats, dst_feats),
+            edge_index = edge_index, 
+            message_kwargs = {
+                "src" : src, 
+                "dst" : dst, 
+                "index" : dst_idx,
+                "edge_features" : edge_features
+            }
+        )
+
+        if self.concat:
+            node_features = node_features.reshape(
+                -1, self.heads * self.out_features_dim
+            )
+        else:
+            node_features = mx.mean(node_features, axis=1)
+
+        if "bias" in self:
+            node_features = node_features + self.bias
+
+        return node_features
+
+    def message(
+        self, 
+        src_features: mx.array, 
+        dst_features: mx.array, 
+        src: mx.array, 
+        dst: mx.array, 
+        index: mx.array, 
+        edge_features: Optional[mx.array] = None, 
+    ) -> mx.array:
+
+        alpha = src + dst 
+
+        if edge_features is not None: 
+            alpha_edge = self._compute_edge_features(edge_features)
+            alpha = alpha + alpha_edge
+
+        alpha = nn.leaky_relu(alpha, self.negative_slope)
+        # Apply attention after non-linearity 
+        alpha = (alpha * self.att).sum(-1)
+
+        alpha = scatter(alpha, index, self.num_nodes, aggr = "softmax")
+
+        if "dropout" in self: 
+            alpha = self.dropout(alpha)
+
+        return mx.expand_dims(alpha, - 1) * src_features
+        
+    def _compute_edge_features(self, edge_features: mx.array):
+        assert all(layer in self for layer in ["edge_lin_proj", "edge_att"]), """Using
+        edge features, GATConv layer should be provided argument
+        `edge_features_dim`."""
+
+        if edge_features.ndim == 1:
+            edge_features = edge_features.reshape(-1, 1)
+
+        edge_features = self.edge_lin_proj(edge_features)
+        edge_features = edge_features.reshape(-1, self.heads, self.out_features_dim)
+
+        return edge_features
+
+    

--- a/mlx_graphs/nn/conv/gatv2_conf.py
+++ b/mlx_graphs/nn/conv/gatv2_conf.py
@@ -27,7 +27,7 @@ class GATv2Conv(MessagePassing):
 
     .. code-block:: python
 
-        conv = GATConv(16, 32, heads=2, concat=True)
+        conv = GATv2Conv(16, 32, heads=2, concat=True)
         edge_index = mx.array([[0, 1, 2, 3, 4], [0, 0, 1, 1, 3]])
         node_features = mx.random.uniform(low=0, high=1, shape=(5, 16))
 

--- a/tests/nn/conv/test_gatv2_conv.py
+++ b/tests/nn/conv/test_gatv2_conv.py
@@ -1,0 +1,48 @@
+import mlx.core as mx
+
+from mlx_graphs.nn.conv.gatv2_conf import GATv2Conv 
+
+mx.random.seed(42)
+
+
+def test_gat_conv():
+    conv = GATv2Conv(8, 20, heads=1)
+
+    node_features = mx.random.uniform(0, 1, [6, 8])
+    edge_index = mx.array([[0, 1, 2, 3], [0, 0, 1, 1]])
+    y_hat1 = conv(edge_index, node_features)
+
+    node_features = mx.random.uniform(-1, 1, [6, 8])
+    edge_index = mx.array([[0, 1, 2, 3], [0, 0, 1, 1]])
+    y_hat2 = conv(edge_index, node_features)
+
+    conv = GATv2Conv(16, 32, heads=1)
+    node_features = mx.random.uniform(0, 1, [100, 16])
+    edge_index = mx.array([[0, 1, 2, 3, 50], [0, 0, 1, 1, 99]])
+    y_hat3 = conv(edge_index, node_features)
+
+    conv = GATv2Conv(16, 32, heads=3, concat=True)
+    node_features = mx.random.uniform(0, 1, [100, 16])
+    edge_index = mx.array([[0, 1, 2, 3, 50], [0, 0, 1, 1, 99]])
+    y_hat4 = conv(edge_index, node_features)
+
+    conv = GATv2Conv(16, 32, heads=3, concat=False)
+    node_features = mx.random.uniform(0, 1, [100, 16])
+    edge_index = mx.array([[0, 1, 2, 3, 50], [0, 0, 1, 1, 99]])
+    y_hat5 = conv(edge_index, node_features)
+
+    conv = GATv2Conv(16, 32, heads=3, concat=False, edge_features_dim=10)
+    node_features = mx.random.uniform(0, 1, [100, 16])
+    edge_features = mx.random.uniform(0, 1, [5, 10])
+    edge_index = mx.array([[0, 1, 2, 3, 50], [0, 0, 1, 1, 99]])
+    y_hat6 = conv(edge_index, node_features, edge_features=edge_features)
+
+    assert y_hat1.shape == (6, 20), "Simple GATv2Conv failed"
+    assert y_hat2.shape == (6, 20), "GATv2Conv with negative values failed"
+    assert y_hat3.shape == (100, 32), "GATv2Conv with different shapes failed"
+    assert y_hat4.shape == (100, 32 * 3), "GATv2Conv with multiple heads concat failed"
+    assert y_hat5.shape == (
+        100,
+        32,
+    ), "GATv2Conv with multiple heads without concat failed"
+    assert y_hat6.shape == (100, 32), "GATv2Conv with edge features failed"

--- a/tests/nn/conv/test_gatv2_conv.py
+++ b/tests/nn/conv/test_gatv2_conv.py
@@ -1,6 +1,6 @@
 import mlx.core as mx
 
-from mlx_graphs.nn.conv.gatv2_conf import GATv2Conv 
+from mlx_graphs.nn.conv.gatv2_conf import GATv2Conv
 
 mx.random.seed(42)
 


### PR DESCRIPTION
## Proposed changes

- I add Gatv2Conv, slightly difference than how it's defined in the paper, based off of [torch geometric's](https://pytorch-geometric.readthedocs.io/en/2.6.1/generated/torch_geometric.nn.conv.GATv2Conv.html)
- testing file for it that is just GatConv's
- an example showcasing the dictionary lookup problem and how Gatv2Conv is able to reach 100% accuracy on it, in comparison to GatConv (Takes a bit to reach 100%, but it does: 110 epochs for me).

(Also fixes typo temporarily comments out node2vec in the .rst until it's re-added, otherwise sphinx will throw an error. Due to it not being used I'm assuming.)


## Checklist

Put an `x` in the boxes that apply.
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have updated the necessary documentation
